### PR TITLE
Generalize exception types in libs

### DIFF
--- a/lib/Exn.fir
+++ b/lib/Exn.fir
@@ -1,8 +1,8 @@
-prim throw(exn: [..r]): [..r] a
+prim throw(exn: exn): exn a
 
-prim try(cb: Fn(): [..exn] a): [..r] Result[[..exn], a]
+prim try(cb: Fn(): exn a): Result[exn, a]
 
-untry(res: Result[[..errs], a]): [..errs] a
+untry(res: Result[exn, a]): exn a
     match res:
         Result.Ok(a): a
         Result.Err(err): throw(err)

--- a/lib/Iter.fir
+++ b/lib/Iter.fir
@@ -10,7 +10,7 @@ trait Iterator[iter, item, exn]:
     mapResult(self: iter, f: Fn(Result[exn, Option[item]]): exn2 Option[b]): MapResult[iter, item, b, exn, exn2]
         MapResult(iter = self, f = f)
 
-    try(self: iter): Try[iter, item, errs]
+    try(self: iter): Try[iter, item, exn]
         Try(iter = self)
 
 trait Step[t]:

--- a/lib/Iter.fir
+++ b/lib/Iter.fir
@@ -4,7 +4,7 @@ trait Iterator[iter, item, exn]:
     map(self: iter, f: Fn(item): exn b): Map[iter, item, b, exn]
         Map(iter = self, f = f)
 
-    peekable(self: iter): Peekable[iter, item]
+    peekable(self: iter): Peekable[iter, item, exn]
         Peekable(iter = self, peeked = Option.None)
 
     mapResult(self: iter, f: Fn(Result[exn, Option[item]]): exn2 Option[b]): MapResult[iter, item, b, exn, exn2]
@@ -61,12 +61,12 @@ impl[Iterator[iter1, a1, exn1]] Iterator[Map[iter1, a1, b1, exn1], b1, exn1]:
             Option.None: Option.None
             Option.Some(a): Option.Some(self.f(a))
 
-type Peekable[iter, item]:
+type Peekable[iter, item, exn]:
     iter: iter
     peeked: Option[item]
 
-impl[Iterator[iter, item, exn]] Iterator[Peekable[iter, item], item, exn]:
-    next(self: Peekable[iter, item]): exn Option[item]
+impl[Iterator[iter, item, exn]] Iterator[Peekable[iter, item, exn], item, exn]:
+    next(self: Peekable[iter, item, exn]): exn Option[item]
         match self.peeked:
             Option.Some(peeked):
                 self.peeked = Option.None
@@ -74,7 +74,7 @@ impl[Iterator[iter, item, exn]] Iterator[Peekable[iter, item], item, exn]:
             Option.None:
                 self.iter.next()
 
-Peekable.peek[Iterator[iter, item, exn]](self: Peekable[iter, item]): exn Option[item]
+Peekable.peek[Iterator[iter, item, exn]](self: Peekable[iter, item, exn]): exn Option[item]
     match self.peeked:
         Option.Some(peeked):
             Option.Some(peeked)

--- a/lib/Iter.fir
+++ b/lib/Iter.fir
@@ -1,13 +1,13 @@
-trait Iterator[iter, item, errs]:
-    next(self: iter): [..errs] Option[item]
+trait Iterator[iter, item, exn]:
+    next(self: iter): exn Option[item]
 
-    map(self: iter, f: Fn(item): [..errs] b): [..errs2] Map[iter, item, b, errs]
+    map(self: iter, f: Fn(item): exn b): Map[iter, item, b, exn]
         Map(iter = self, f = f)
 
-    peekable(self: iter): [..errs] Peekable[iter, item]
+    peekable(self: iter): Peekable[iter, item]
         Peekable(iter = self, peeked = Option.None)
 
-    mapResult(self: iter, f: Fn(Result[[..errs], Option[item]]): [..errsNew] Option[b]): MapResult[iter, item, b, errs, errsNew]
+    mapResult(self: iter, f: Fn(Result[exn, Option[item]]): exn2 Option[b]): MapResult[iter, item, b, exn, exn2]
         MapResult(iter = self, f = f)
 
     try(self: iter): Try[iter, item, errs]
@@ -26,8 +26,8 @@ type RangeIterator[t]:
     current: t
     end: t
 
-impl[Step[t], Ord[t]] Iterator[RangeIterator[t], t, errs]:
-    next(self: RangeIterator[t]): [..errs] Option[t]
+impl[Step[t], Ord[t]] Iterator[RangeIterator[t], t, exn]:
+    next(self: RangeIterator[t]): exn Option[t]
         if self.current >= self.end:
             Option.None
         else:
@@ -39,8 +39,8 @@ type InclusiveRangeIterator[t]:
     current: t
     end: t
 
-impl[Step[t], Ord[t]] Iterator[InclusiveRangeIterator[t], t, errs]:
-    next(self: InclusiveRangeIterator[t]): [..errs] Option[t]
+impl[Step[t], Ord[t]] Iterator[InclusiveRangeIterator[t], t, exn]:
+    next(self: InclusiveRangeIterator[t]): exn Option[t]
         if self.current > self.end:
             Option.None
         else:
@@ -49,14 +49,14 @@ impl[Step[t], Ord[t]] Iterator[InclusiveRangeIterator[t], t, errs]:
             Option.Some(current)
 
 # NOTE: The row type parameter needs to start with `recRow` to have kind `row(variant)`.
-type Map[iter, a, b, recRowErrs]:
+type Map[iter, a, b, exn]:
     iter: iter
-    f: Fn(a): [..recRowErrs] b
+    f: Fn(a): exn b
 
 # BUG(#86): To work around substitution bugs, give quantified variables
 # different names than the quantified variables of `Iterator`.
-impl[Iterator[iter1, a1, errs1]] Iterator[Map[iter1, a1, b1, errs1], b1, errs1]:
-    next(self: Map[iter1, a1, b1, errs1]): [..errs1] Option[b1]
+impl[Iterator[iter1, a1, exn1]] Iterator[Map[iter1, a1, b1, exn1], b1, exn1]:
+    next(self: Map[iter1, a1, b1, exn1]): exn1 Option[b1]
         match self.iter.next():
             Option.None: Option.None
             Option.Some(a): Option.Some(self.f(a))
@@ -65,8 +65,8 @@ type Peekable[iter, item]:
     iter: iter
     peeked: Option[item]
 
-impl[Iterator[iter, item, errs]] Iterator[Peekable[iter, item], item, errs]:
-    next(self: Peekable[iter, item]): [..errs] Option[item]
+impl[Iterator[iter, item, exn]] Iterator[Peekable[iter, item], item, exn]:
+    next(self: Peekable[iter, item]): exn Option[item]
         match self.peeked:
             Option.Some(peeked):
                 self.peeked = Option.None
@@ -74,7 +74,7 @@ impl[Iterator[iter, item, errs]] Iterator[Peekable[iter, item], item, errs]:
             Option.None:
                 self.iter.next()
 
-Peekable.peek[Iterator[iter, item, errs]](self: Peekable[iter, item]): [..errs] Option[item]
+Peekable.peek[Iterator[iter, item, exn]](self: Peekable[iter, item]): exn Option[item]
     match self.peeked:
         Option.Some(peeked):
             Option.Some(peeked)
@@ -82,20 +82,20 @@ Peekable.peek[Iterator[iter, item, errs]](self: Peekable[iter, item]): [..errs] 
             self.peeked = self.iter.next()
             self.peeked
 
-type MapResult[iter, item, b, varRowErrsOld, varRowErrsNew]:
+type MapResult[iter, item, b, exnOld, exnNew]:
     iter: iter
-    f: Fn(Result[[..varRowErrsOld], Option[item]]): [..varRowErrsNew] Option[b]
+    f: Fn(Result[exnOld, Option[item]]): exnNew Option[b]
 
-impl[Iterator[iter1, item1, varRowErrsOld1]] Iterator[MapResult[iter1, item1, b1, varRowErrsOld1, varRowErrsNew1], b1, varRowErrsNew1]:
-    next(self: MapResult[iter1, item1, b1, varRowErrsOld1, varRowErrsNew1]): [..varRowErrsNew1] Option[b1]
+impl[Iterator[iter1, item1, exnOld1]] Iterator[MapResult[iter1, item1, b1, exnOld1, exnNew1], b1, exnNew1]:
+    next(self: MapResult[iter1, item1, b1, exnOld1, exnNew1]): exnNew1 Option[b1]
         self.f(try(self.iter.next))
 
-type Try[iter, item, errs]:
+type Try[iter, item, exn]:
     iter: iter
 
-impl[Iterator[iter1, item1, varRowErrs1]] Iterator[Try[iter1, item1, varRowErrs1], Result[[..varRowErrs1], item1], varRowErrs2]:
-    next(self: Try[iter1, item1, varRowErrs1]): [..varRowErrs2] Option[Result[[..varRowErrs1], item1]]
-        match try(fn(): [..varRowErrs1] Option[item1] { self.iter.next() }):
+impl[Iterator[iter1, item1, exn1]] Iterator[Try[iter1, item1, exn1], Result[exn1, item1], exn2]:
+    next(self: Try[iter1, item1, exn1]): exn2 Option[Result[exn1, item1]]
+        match try(fn(): exn1 Option[item1] { self.iter.next() }):
             Result.Err(err): Option.Some(Result.Err(err))
             Result.Ok(Option.Some(item)): Option.Some(Result.Ok(item))
             Result.Ok(Option.None): Option.None

--- a/lib/Str.fir
+++ b/lib/Str.fir
@@ -136,8 +136,8 @@ CharIter.asStr(self): Str
         _len = self._end - self._idx
     )
 
-impl Iterator[CharIter, Char, errs]:
-    next(self: CharIter): [..errs] Option[Char]
+impl Iterator[CharIter, Char, exn]:
+    next(self: CharIter): exn Option[Char]
         if self._idx == self._end:
             return Option.None
 
@@ -150,8 +150,8 @@ type CharIndices:
     _str: Str
     _idx: U32
 
-impl Iterator[CharIndices, (char: Char, idx: U32), errs]:
-    next(self: CharIndices): [..errs] Option[(char: Char, idx: U32)]
+impl Iterator[CharIndices, (char: Char, idx: U32), exn]:
+    next(self: CharIndices): exn Option[(char: Char, idx: U32)]
         if self._idx == self._str.len():
             return Option.None
 
@@ -194,8 +194,8 @@ type SplitWhitespace:
     _str: Str
     _idx: U32
 
-impl Iterator[SplitWhitespace, Str, errs]:
-    next(self: SplitWhitespace): [..errs] Option[Str]
+impl Iterator[SplitWhitespace, Str, exn]:
+    next(self: SplitWhitespace): exn Option[Str]
         let wordStart = self._idx
         let wordEnd = wordStart
         let charIdxIter = self._str.substr(wordStart, self._str.len()).charIndices()
@@ -233,8 +233,8 @@ type Lines:
     _str: Str
     _idx: U32
 
-impl Iterator[Lines, Str, errs]:
-    next(self: Lines): [..errs] Option[Str]
+impl Iterator[Lines, Str, exn]:
+    next(self: Lines): exn Option[Str]
         let lineStart = self._idx
         let charIdxIter = self._str.substr(lineStart, self._str.len()).charIndices()
 

--- a/lib/Vec.fir
+++ b/lib/Vec.fir
@@ -111,8 +111,8 @@ type VecIter[t]:
     _vec: Vec[t]
     _idx: U32
 
-impl Iterator[VecIter[t], t, errs]:
-    next(self: VecIter[t]): [..errs] Option[t]
+impl Iterator[VecIter[t], t, exn]:
+    next(self: VecIter[t]): exn Option[t]
         if self._idx >= self._vec.len():
             return Option.None
 

--- a/src/monomorph.rs
+++ b/src/monomorph.rs
@@ -1464,10 +1464,10 @@ fn mono_tc_ty(
     mono_pgm: &mut MonoPgm,
 ) -> mono::Type {
     match ty.clone() {
+        // TODO: When defaulting exception types we should use empty variant instead of record, to
+        // indicate that the function doesn't throw.
         Ty::Var(var) => match var.kind() {
-            Kind::Star => {
-                panic!("Type variable: {:?}", var);
-            }
+            Kind::Star => mono::Type::Record { fields: vec![] },
             Kind::Row(RecordOrVariant::Record) => mono::Type::Record { fields: vec![] },
             Kind::Row(RecordOrVariant::Variant) => mono::Type::Variant { alts: vec![] },
         },

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -136,14 +136,10 @@ fn add_exception_types(module: &mut ast::Module) {
     }
 }
 
-// The default exception type: `[..?exn]`.
+// The default exception type: `?exn`.
 fn exn_type(module: std::rc::Rc<str>, line: u16) -> ast::L<ast::Type> {
     ast::L {
-        node: ast::Type::Variant {
-            alts: Default::default(),
-            extension: Some(EXN_QVAR_ID),
-            is_row: false,
-        },
+        node: ast::Type::Var(EXN_QVAR_ID),
         loc: ast::Loc {
             module,
             line_start: line,
@@ -1021,12 +1017,7 @@ fn collect_schemes(
                         trait_fun_scheme = trait_fun_scheme.subst(&ty_param_renamed, &ty_arg);
                     }
 
-                    if !trait_fun_scheme.eq_modulo_alpha(
-                        tys.cons(),
-                        &Default::default(),
-                        &impl_fun_scheme,
-                        &fun.loc,
-                    ) {
+                    if !trait_fun_scheme.eq_modulo_alpha(tys.cons(), &impl_fun_scheme, &fun.loc) {
                         panic!(
                             "{}: Trait method implementation of {} does not match the trait method type
                                 Trait method type:          {}
@@ -1418,9 +1409,9 @@ fn resolve_preds(
     if !goals.is_empty() {
         use std::fmt::Write;
         let mut msg = String::new();
-        write!(&mut msg, "Unable to resolve predicates:").unwrap();
+        writeln!(&mut msg, "Unable to resolve predicates:").unwrap();
         for goal in goals {
-            write!(&mut msg, "{}: {}", loc_display(&goal.loc.clone()), goal).unwrap();
+            writeln!(&mut msg, "{}: {}", loc_display(&goal.loc.clone()), goal).unwrap();
         }
         panic!("{}", msg);
     }

--- a/src/type_checker/stmt.rs
+++ b/src/type_checker/stmt.rs
@@ -312,35 +312,13 @@ fn check_stmt(
 
             *tc_ty = Some(item_ty_var.clone());
 
-            let call_site_exc_ty = &tc_state.exceptions;
-
-            let iter_trait_exc_ty_var = tc_state.var_gen.new_var(
-                level,
-                Kind::Row(RecordOrVariant::Variant),
-                expr.loc.clone(),
-            );
-
-            unify(
-                call_site_exc_ty,
-                &Ty::Anonymous {
-                    labels: Default::default(),
-                    extension: Some(Box::new(Ty::Var(iter_trait_exc_ty_var.clone()))),
-                    kind: RecordOrVariant::Variant,
-                    is_row: false,
-                },
-                tc_state.tys.tys.cons(),
-                tc_state.var_gen,
-                level,
-                &expr.loc,
-            );
-
             // Add predicate `Iterator[iter, item]`.
             tc_state.preds.insert(Pred {
                 trait_: SmolStr::new_static("Iterator"),
                 params: vec![
                     Ty::Var(iterator_ty_var.clone()),
                     item_ty_var.clone(),
-                    Ty::Var(iter_trait_exc_ty_var),
+                    tc_state.exceptions.clone(),
                 ],
                 loc: stmt.loc.clone(),
             });

--- a/src/type_checker/unification.rs
+++ b/src/type_checker/unification.rs
@@ -169,7 +169,7 @@ pub(super) fn unify(
             },
         ) => {
             // TODO: Are these type errors or bugs?
-            assert_eq!(kind1, kind2);
+            assert_eq!(kind1, kind2, "{}", loc_display(loc));
 
             if is_row_1 != is_row_2 {
                 panic!(

--- a/tests/ExnFail4.fir
+++ b/tests/ExnFail4.fir
@@ -4,4 +4,10 @@ f1()
 # args: --typecheck --no-backtrace
 # expected exit status: 101
 # expected stderr:
-# tests/ExnFail4.fir:2:5: Unable to unify variant with constructors {"A"} with variant with constructors {}
+# tests/ExnFail4.fir:2:5: Unable to unify types
+#              [A: (), .._2] and
+#              ?exn
+#              (
+#                 Anonymous { labels: {"A": Anonymous { labels: {}, extension: None, kind: Record, is_row: false }}, extension: Some(Var(TyVarRef(TyVar { id: 2, kind: Row(Variant), level: 0, link: None, loc: tests/ExnFail4.fir:2:11-2:13 }))), kind: Variant, is_row: false }
+#                 Con("?exn")
+#              )

--- a/tests/Peekable.fir
+++ b/tests/Peekable.fir
@@ -1,8 +1,8 @@
 type Iter:
     next: U32
 
-impl Iterator[Iter, U32, errs]:
-    next(self: Iter): [..errs] Option[U32]
+impl Iterator[Iter, U32, exn]:
+    next(self: Iter): exn Option[U32]
         if self.next == 3:
             printStr("Stopping")
             Option.None

--- a/tests/Peekable.fir
+++ b/tests/Peekable.fir
@@ -14,7 +14,7 @@ impl Iterator[Iter, U32, exn]:
 
 main
     let iter = Iter(next = 0)
-    let peekable: Peekable[Iter, U32] = iter.peekable()
+    let peekable = iter.peekable()
     let next: Option[U32] = peekable.next()
     printStr(next.toStr())
     let next: Option[U32] = peekable.peek()

--- a/tests/TcFail1.fir
+++ b/tests/TcFail1.fir
@@ -12,5 +12,5 @@ impl T[Str]:
 # expected exit status: 101
 # expected stderr:
 # tests/TcFail1.fir:8:5: Trait method implementation of toStr does not match the trait method type
-#                                 Trait method type:          [?exn#0: row(variant)] Fn(Str): [..?exn#0] Str
-#                                 Implementation method type: [?exn: row(variant)] Fn(Str): [..?exn] I32
+#                                 Trait method type:          [?exn#0: *] Fn(Str): ?exn#0 Str
+#                                 Implementation method type: [?exn: *] Fn(Str): ?exn I32

--- a/tests/ThrowNonVariant.fir
+++ b/tests/ThrowNonVariant.fir
@@ -1,0 +1,6 @@
+test: U32 Str
+    throw(123u32)
+
+main = printStr(try(test).toStr())
+
+# expected stdout: Result.Err(123)

--- a/tests/TraitImplFail2.fir
+++ b/tests/TraitImplFail2.fir
@@ -11,5 +11,5 @@ impl T[I32]:
 # expected exit status: 101
 # expected stderr:
 # tests/TraitImplFail2.fir:7:5: Trait method implementation of a does not match the trait method type
-#                                 Trait method type:          [?exn#0: row(variant)] Fn(I32): [..?exn#0] ()
-#                                 Implementation method type: [a: *, ?exn: row(variant)] Fn(a): [..?exn] ()
+#                                 Trait method type:          [?exn#0: *] Fn(I32): ?exn#0 ()
+#                                 Implementation method type: [a: *, ?exn: *] Fn(a): ?exn ()

--- a/tests/TraitImplFail4.fir
+++ b/tests/TraitImplFail4.fir
@@ -10,5 +10,5 @@ impl T[I32]:
 # expected exit status: 101
 # expected stderr:
 # tests/TraitImplFail4.fir:7:5: Trait method implementation of a does not match the trait method type
-#                                 Trait method type:          [?exn#0: row(variant)] Fn(I32): [..?exn#0] ()
-#                                 Implementation method type: [?exn: row(variant)] Fn(I32): [..?exn] I32
+#                                 Trait method type:          [?exn#0: *] Fn(I32): ?exn#0 ()
+#                                 Implementation method type: [?exn: *] Fn(I32): ?exn I32


### PR DESCRIPTION
Prior to to 5496083 we had to use variant type syntax in the function exception
types.

Now that we can use any type (other than function types), generalize exception
types in the standard library from variant types to `*`.

This generalizes `throw`, `try`, and `untry`, and allows throwing any value,
not just variants.