### PR TITLE
Unchecked exceptions

### DIFF
--- a/lib/Exn.fir
+++ b/lib/Exn.fir
@@ -1,4 +1,7 @@
-prim throw(exn: exn) a / exn
+prim throwUnchecked(exn: exn) a
+
+throw(exn: exn) a / exn:
+    throwUnchecked(exn)
 
 prim try(cb: Fn() a / exn) Result[exn, a]
 

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -203,7 +203,7 @@ pub enum BuiltinFunDecl {
     /// `prim throw(exn: [..r]): {..r} a`
     ///
     /// This function never throws or returns, so we don't need the exception and return types.
-    Throw,
+    ThrowUnchecked,
 
     /// `prim try(cb: Fn(): {..exn} a): {..r} Result[[..exn], a]`
     ///
@@ -946,10 +946,12 @@ pub fn lower(mono_pgm: &mut mono::MonoPgm) -> LoweredPgm {
                             .push(Fun::Builtin(BuiltinFunDecl::Try { exn, a }));
                     }
 
-                    "throw" => {
-                        // prim throw(exn: [..r]): {..r} a
-                        assert_eq!(fun_ty_args.len(), 2); // r, a
-                        lowered_pgm.funs.push(Fun::Builtin(BuiltinFunDecl::Throw));
+                    "throwUnchecked" => {
+                        // prim throwUnchecked(exn: exn): a / {..r}
+                        assert_eq!(fun_ty_args.len(), 3); // exn, a, r
+                        lowered_pgm
+                            .funs
+                            .push(Fun::Builtin(BuiltinFunDecl::ThrowUnchecked));
                     }
 
                     "readFileUtf8" => {

--- a/tests/ThrowUnchecked.fir
+++ b/tests/ThrowUnchecked.fir
@@ -1,0 +1,37 @@
+main():
+    printNoNl("Calling f... ")
+    match try(f):
+        Result.Ok(()): print("OK")
+        Result.Err(~FooError.FooError): print("FooError")
+        Result.Err(~AssertionError.AssertionError): print("AssertError")
+
+    printNoNl("Calling g... ")
+    match try(g):
+        Result.Ok(()): print("OK")
+        Result.Err(~FooError.FooError): print("FooError")
+        Result.Err(~AssertionError.AssertionError): print("AssertionError")
+
+    g()
+
+f() / [FooError, ..exn]:
+    throw(~FooError.FooError)
+
+g():
+    throwUnchecked(~AssertionError.AssertionError)
+
+type FooError:
+    FooError
+
+type AssertionError:
+    AssertionError
+
+# args: --no-backtrace
+# expected exit status: 101
+# expected stdout:
+# Calling f... FooError
+# Calling g... AssertionError
+
+# expected stderr:
+# tests/ThrowUnchecked.fir:3:5: Unexhaustive pattern match
+# tests/ThrowUnchecked.fir:9:5: Unexhaustive pattern match
+# Uncaught exception


### PR DESCRIPTION
Fixes #158.

---

TODOs:

- We should attach stack traces to at least unchecked exceptions, and also only allow throwing `ToStr`s. This requires trait objects though, which we don't have yet. Maybe just add stack traces + a string for now and show those.
- Update the compiler's assertion functions, maybe move them to standard libs.