### PR TITLE
PEG: Take iterator as input

### DIFF
--- a/lib/Iter.fir
+++ b/lib/Iter.fir
@@ -68,7 +68,7 @@ trait Iterator[iter, item, exn]:
     size(self: iter) Option[U32]:
         Option.None
 
-    enumerate(self: iter) Enumerate[iter, item, exn]:
+    enumerate(self: iter) Enumerate[iter]:
         Enumerate(iter = self, idx = 0)
 
 # --------------------------------------------------------------------------------------------------
@@ -344,14 +344,14 @@ impl[Iterator[iter, item, exn]] Iterator[Filter[iter, item, exn], item, exn]:
 
 # --------------------------------------------------------------------------------------------------
 
-type Enumerate[iter, item, exn](
+type Enumerate[iter](
     iter: iter,
     idx: U32,
 )
 
 # TODO: Maybe update item type to `(U32, item)` once we have records with positional fields.
-impl[Iterator[iter, item, exn]] Iterator[Enumerate[iter, item, exn], (idx: U32, item: item), exn]:
-    next(self: Enumerate[iter, item, exn]) Option[(idx: U32, item: item)] / exn:
+impl[Iterator[iter, item, exn]] Iterator[Enumerate[iter], (idx: U32, item: item), exn]:
+    next(self: Enumerate[iter]) Option[(idx: U32, item: item)] / exn:
         match self.iter.next():
             Option.None:
                 Option.None
@@ -360,9 +360,9 @@ impl[Iterator[iter, item, exn]] Iterator[Enumerate[iter, item, exn], (idx: U32, 
                 self.idx += 1
                 Option.Some((idx = idx, item = item))
 
-    size(self: Enumerate[iter, item, exn]) Option[U32] / exn2:
+    size(self: Enumerate[iter]) Option[U32] / exn2:
         self.iter.size[iter, item, exn, exn2]()
 
-impl[Clone[iter]] Clone[Enumerate[iter, item, exn]]:
-    clone(self: Enumerate[iter, item, exn]) Enumerate[iter, item, exn]:
+impl[Clone[iter]] Clone[Enumerate[iter]]:
+    clone(self: Enumerate[iter]) Enumerate[iter]:
         Enumerate(iter = self.iter.clone(), idx = self.idx)

--- a/lib/Vec.fir
+++ b/lib/Vec.fir
@@ -180,3 +180,7 @@ impl Iterator[VecIter[t], t, exn]:
         let val = self._vec.get(self._idx)
         self._idx += 1
         Option.Some(val)
+
+impl Clone[VecIter[t]]:
+    clone(self: VecIter[t]) VecIter[t]:
+        VecIter(_vec = self._vec, _idx = self._idx)

--- a/tools/peg/Peg.fir
+++ b/tools/peg/Peg.fir
@@ -548,7 +548,7 @@ generateSymbolParser(
                 SymbolCont.Ignore:
                     Doc.str("()")
 
-            Doc.nested(
+            doc + Doc.nested(
                 4,
                 Doc.str("match iter.next():")
                     + Doc.hardLine()
@@ -763,7 +763,7 @@ generateSymbolParser(
             # code with a try to handle failure.
 
             # On success: update the cursors.
-            let okDoc = Doc.str("curErr = ParseError.takeAdvancedOpt(curErr, newErr)")
+            let okDoc = Doc.str("curErr = ParseError.takeAdvancedOpt(curErr, ok.err)")
 
             # On failure: update the cursors and pop any pushed tokens.
             let errDoc =
@@ -794,7 +794,7 @@ generateSymbolParser(
                 SymbolCont.Push(_) | SymbolCont.PushToParseTree(_) | SymbolCont.Ignore:
                     # Value of `try`. Symbol parser directly pushes to the vectors, or ignores, so
                     # we don't have a `val` field here.
-                    Doc.str("curErr")
+                    Doc.str("(err = curErr)")
 
             let doc = Doc.empty()
             if cont is SymbolCont.PushToParseTree(_):
@@ -823,7 +823,7 @@ generateSymbolParser(
                            + Doc.hardLine()
                            + Doc.nested(
                                4,
-                               Doc.str("Result.Ok(newErr):")
+                               Doc.str("Result.Ok(ok):")
                                    + Doc.hardLine()
                                    + okDoc))
 
@@ -878,18 +878,20 @@ generateSymbolParser(
                             + Doc.str("U32.max()")))
 
         Symbol.Cursor:
-            match cont:
-                SymbolCont.Bind(local):
-                    Doc.str("let `local` = cursor")
+            Doc.str("let cursor = iter.next[iter, (idx: U32, token: `terminalType`), ParseError]().map(|item: (idx: U32, token: `terminalType`)|: item.idx).unwrapOr(U32.max())")
+                + Doc.hardLine()
+                + (match cont:
+                       SymbolCont.Bind(local):
+                           Doc.str("let `local` = cursor")
 
-                SymbolCont.Push(vecLocal):
-                    Doc.str("`vecLocal`.push(cursor)")
+                       SymbolCont.Push(vecLocal):
+                           Doc.str("`vecLocal`.push(cursor)")
 
-                SymbolCont.PushToParseTree(_):
-                    panic("Can't push cursor location to parse tree")
+                       SymbolCont.PushToParseTree(_):
+                           panic("Can't push cursor location to parse tree")
 
-                SymbolCont.Ignore:
-                    Doc.empty()
+                       SymbolCont.Ignore:
+                           Doc.empty())
 
 tokensToCode(tokens: Vec[Token]) Str / exn:
     if tokens.len() == 0:

--- a/tools/peg/Peg.fir
+++ b/tools/peg/Peg.fir
@@ -407,7 +407,7 @@ generateNonTerminal(terminalType: Str, nonTerminalType: Str, decl: NonTerminalDe
         Option.None:
             Doc.str("ParseTree[`terminalType`, `nonTerminalType`]")
 
-    let doc = Doc.str("`decl.name`[Iterator[iter, (idx: U32, token: `terminalType`), ParseError], Clone[iter]](iter: iter) (tree: ")
+    let doc = Doc.str("`decl.name`[Iterator[iter, (idx: U32, item: `terminalType`), ParseError], Clone[iter]](iter: iter) (tree: ")
                 + returnTy
                 + Doc.str(", newErr: Option[ParseError]) / ParseError:")
                 + Doc.hardLine()
@@ -554,7 +554,7 @@ generateSymbolParser(
                     + Doc.hardLine()
                     + Doc.nested(
                         4,
-                        Doc.str("Option.Some((idx, token)):")
+                        Doc.str("Option.Some((idx, item = token)):")
                             + Doc.hardLine()
                             + Doc.nested(
                                 4,
@@ -855,7 +855,7 @@ generateSymbolParser(
                                 + Doc.hardLine()
                                 + Doc.str("iter = iter0.clone()")
                                 + Doc.hardLine()
-                                + makeThrow(Doc.str("ParseError.takeAdvanced(curErr, ParseError(cursor = iter0.clone().next[iter, (idx: U32, token: `terminalType`), ParseError]().unwrap().idx))"))))
+                                + makeThrow(Doc.str("ParseError.takeAdvanced(curErr, ParseError(cursor = iter0.clone().next[iter, (idx: U32, item: `terminalType`), ParseError]().unwrap().idx))"))))
 
         Symbol.Bind(binder, symbol):
             generateSymbolParser(terminalType, symbol, terminalPats, SymbolCont.Bind(binder))
@@ -863,11 +863,11 @@ generateSymbolParser(
         Symbol.EndOfInput:
             Doc.nested(
                 4,
-                Doc.str("match iter.next[iter, (idx: U32, token: `terminalType`), ParseError]():")
+                Doc.str("match iter.next[iter, (idx: U32, item: `terminalType`), ParseError]():")
                     + Doc.hardLine()
                     + Doc.nested(
                         4,
-                        Doc.str("Option.Some((idx, token)):")
+                        Doc.str("Option.Some((idx, item = token)):")
                             + Doc.hardLine()
                             + makeThrow(Doc.str("ParseError.takeAdvanced(curErr, ParseError(cursor = idx))")))
                     + Doc.hardLine()
@@ -878,7 +878,7 @@ generateSymbolParser(
                             + Doc.str("U32.max()")))
 
         Symbol.Cursor:
-            Doc.str("let cursor = iter.next[iter, (idx: U32, token: `terminalType`), ParseError]().map(|item: (idx: U32, token: `terminalType`)|: item.idx).unwrapOr(U32.max())")
+            Doc.str("let cursor = iter.next[iter, (idx: U32, item: `terminalType`), ParseError]().map(|item: (idx: U32, item: `terminalType`)|: item.idx).unwrapOr(U32.max())")
                 + Doc.hardLine()
                 + (match cont:
                        SymbolCont.Bind(local):

--- a/tools/peg/Peg.fir
+++ b/tools/peg/Peg.fir
@@ -407,12 +407,12 @@ generateNonTerminal(terminalType: Str, nonTerminalType: Str, decl: NonTerminalDe
         Option.None:
             Doc.str("ParseTree[`terminalType`, `nonTerminalType`]")
 
-    let doc = Doc.str("`decl.name`(tokens: Vec[`terminalType`], cursor: U32) (tree: ")
+    let doc = Doc.str("`decl.name`[Iterator[iter, (idx: U32, token: `terminalType`), ParseError], Clone[iter]](iter: iter) (tree: ")
                 + returnTy
-                + Doc.str(", newCursor: U32, newErr: Option[ParseError]) / ParseError:")
+                + Doc.str(", newErr: Option[ParseError]) / ParseError:")
                 + Doc.hardLine()
 
-    doc += Doc.str("let cursor0 = cursor") + Doc.hardLine()
+    doc += Doc.str("let iter0 = iter.clone()") + Doc.hardLine()
     doc += Doc.str("let curErr: Option[ParseError] = Option.None") + Doc.hardLine()
 
     for alt: Alt in decl.alts.iter():
@@ -430,7 +430,7 @@ generateNonTerminal(terminalType: Str, nonTerminalType: Str, decl: NonTerminalDe
             SymbolCont.PushToParseTree("nodes")
 
         for symbol: Symbol in alt.symbols.iter():
-            altResultDoc += generateSymbolParser(symbol, terminalPats, symbolCont) + Doc.hardLine()
+            altResultDoc += generateSymbolParser(terminalType, symbol, terminalPats, symbolCont) + Doc.hardLine()
 
         let valueDoc = match alt.rhs:
             Option.None:
@@ -455,7 +455,7 @@ generateNonTerminal(terminalType: Str, nonTerminalType: Str, decl: NonTerminalDe
 
         altResultDoc += Doc.hardLine()
 
-        altResultDoc += Doc.str("(value = value, cursor = cursor, err = curErr)")
+        altResultDoc += Doc.str("(value = value, err = curErr)")
 
         altResultDoc = altResultDoc.nest(4)
 
@@ -473,20 +473,22 @@ generateNonTerminal(terminalType: Str, nonTerminalType: Str, decl: NonTerminalDe
                     + Doc.hardLine()
                     + makeUpdateError()
                     + Doc.hardLine()
-                    + Doc.str("cursor = cursor0"))
+                    + Doc.str("iter = iter0.clone()"))
 
         let okAlt =
             Doc.nested(
                 4,
-                Doc.str("Result.Ok((value = value, cursor = newCursor, err = newErr)):")
+                Doc.str("Result.Ok((value = value, err = newErr)):")
                     + Doc.hardLine()
-                    + Doc.str("return (tree = value, newCursor = newCursor, newErr = newErr)"))
+                    + Doc.str("return (tree = value, newErr = newErr)"))
 
         altResultMatchDoc = Doc.nested(4, altResultMatchDoc + errAlt) + Doc.nested(4, Doc.hardLine() + okAlt)
 
         doc += altResultMatchDoc + Doc.hardLine()
 
-    doc += makeThrow(makeUnexpectedTokenError())
+    # We reach here when all of the alternatives fail. Because there needs to be at least one
+    # alternative, it means that at least one of them failed, so `curErr` should be set.
+    doc += makeThrow(Doc.str("curErr.unwrap()"))
 
     doc.nest(4)
 
@@ -519,6 +521,7 @@ type SymbolCont:
 ## use site of this function should return the value of `cursor` from the closure so that the
 ## non-terminal function's `cursor` can be updated with the new value.
 generateSymbolParser(
+    terminalType: Str,
     symbol: Symbol,
     terminalPats: HashMap[Str, Vec[Token]],
     cont: SymbolCont,
@@ -532,43 +535,49 @@ generateSymbolParser(
             if cont is SymbolCont.Bind(local):
                 doc += Doc.str("let `local` = ")
 
-            let tokenKindCheck = Doc.str("if tokens.getOpt(cursor) is Option.Some(sym) and sym is ")
-                + Doc.str(tokensToCode(patToks))
-                + Doc.char(':')
-                + Doc.hardLine()
-
             let nested = match cont:
                 SymbolCont.Bind(local):
-                     Doc.str("cursor += 1")
-                        + Doc.hardLine()
-                        + Doc.str("sym")
+                    Doc.str("token")
 
                 SymbolCont.Push(vecLocal):
-                    Doc.str("`vecLocal`.push(sym)")
-                        + Doc.hardLine()
-                        + Doc.str("cursor += 1")
+                    Doc.str("`vecLocal`.push(token)")
 
                 SymbolCont.PushToParseTree(vecLocal):
-                    Doc.str("`vecLocal`.push(ParseTree.Terminal(sym))")
-                        + Doc.hardLine()
-                        + Doc.str("cursor += 1")
+                    Doc.str("`vecLocal`.push(ParseTree.Terminal(token))")
 
                 SymbolCont.Ignore:
-                    Doc.str("cursor += 1")
+                    Doc.str("()")
 
-            tokenKindCheck = Doc.nested(4, tokenKindCheck + nested) + Doc.hardLine()
-
-            doc + tokenKindCheck +
-                Doc.nested(
-                    4,
-                    Doc.str("else:")
-                        + Doc.hardLine()
-                        + makeThrow(makeUnexpectedTokenError()))
+            Doc.nested(
+                4,
+                Doc.str("match iter.next():")
+                    + Doc.hardLine()
+                    + Doc.nested(
+                        4,
+                        Doc.str("Option.Some((idx, token)):")
+                            + Doc.hardLine()
+                            + Doc.nested(
+                                4,
+                                Doc.str("if token is ")
+                                    + Doc.str(tokensToCode(patToks))
+                                    + Doc.char(':')
+                                    + Doc.hardLine()
+                                    + nested)
+                            + Doc.hardLine()
+                            + Doc.nested(
+                                4,
+                                Doc.str("else:")
+                                    + Doc.hardLine()
+                                    + makeThrow(makeUnexpectedTokenError())))
+                    + Doc.hardLine()
+                    + Doc.nested(
+                        4,
+                        Doc.str("Option.None:")
+                            + Doc.hardLine()
+                            + Doc.str("throw(ParseError(cursor = U32.max()))")))
 
         Symbol.NonTerminal(nonTerminal):
-            let doc = Doc.str("let nonTerminalResult = `nonTerminal`(tokens, cursor)")
-                + Doc.hardLine()
-                + Doc.str("cursor = nonTerminalResult.newCursor")
+            let doc = Doc.str("let nonTerminalResult = `nonTerminal`(iter)")
                 + Doc.hardLine()
                 + Doc.str("curErr = nonTerminalResult.newErr")
 
@@ -604,7 +613,7 @@ generateSymbolParser(
                 else:
                     SymbolCont.Ignore
 
-                doc += generateSymbolParser(symbol, terminalPats, cont)
+                doc += generateSymbolParser(terminalType, symbol, terminalPats, cont)
 
                 symIdx += 1
 
@@ -626,7 +635,7 @@ generateSymbolParser(
                     SymbolCont.PushToParseTree(vecLocal):
                         SymbolCont.PushToParseTree(vecLocal)
 
-                doc += generateSymbolParser(symbol, terminalPats, symbolCont)
+                doc += generateSymbolParser(terminalType, symbol, terminalPats, symbolCont)
 
                 symIdx += 1
 
@@ -694,9 +703,9 @@ generateSymbolParser(
                         4,
                         Doc.str("let symResult = try(||:")
                             + Doc.hardLine()
-                            + generateSymbolParser(symbol, terminalPats, symbolCont)
+                            + generateSymbolParser(terminalType, symbol, terminalPats, symbolCont)
                             + Doc.hardLine()
-                            + Doc.str("(cursor = cursor, err = curErr)"))
+                            + Doc.str("curErr"))
                     + Doc.hardLine()
                     + Doc.str(")")
                     + Doc.hardLine()
@@ -718,11 +727,9 @@ generateSymbolParser(
                             + Doc.hardLine()
                             + Doc.nested(
                                 4,
-                                Doc.str("Result.Ok(ok):")
+                                Doc.str("Result.Ok(newErr):")
                                     + Doc.hardLine()
-                                    + Doc.str("cursor = ok.cursor")
-                                    + Doc.hardLine()
-                                    + Doc.str("curErr = ParseError.takeAdvancedOpt(curErr, ok.err)"))))
+                                    + Doc.str("curErr = ParseError.takeAdvancedOpt(curErr, newErr)"))))
 
             doc
 
@@ -747,19 +754,16 @@ generateSymbolParser(
                     # `_"foo"*`.
                     SymbolCont.Ignore
 
-            doc + generateSymbolParser(symbol, terminalPats, symbolCont)
+            doc + generateSymbolParser(terminalType, symbol, terminalPats, symbolCont)
                 + Doc.hardLine()
-                + generateSymbolParser(Symbol.ZeroOrMore(symbol), terminalPats, symbolCont)
+                + generateSymbolParser(terminalType, Symbol.ZeroOrMore(symbol), terminalPats, symbolCont)
 
         Symbol.Optional(symbol):
             # Compile `symbol` with the continuation of the current symbol (`symbol?`), but wrap the
             # code with a try to handle failure.
 
             # On success: update the cursors.
-            let okDoc =
-                Doc.str("cursor = ok.cursor")
-                    + Doc.hardLine()
-                    + Doc.str("curErr = ParseError.takeAdvancedOpt(curErr, ok.err)")
+            let okDoc = Doc.str("curErr = ParseError.takeAdvancedOpt(curErr, newErr)")
 
             # On failure: update the cursors and pop any pushed tokens.
             let errDoc =
@@ -785,12 +789,12 @@ generateSymbolParser(
                     errDoc += Doc.hardLine() + Doc.str("Option.None")
 
                     # Value of `try`.
-                    Doc.str("(cursor = cursor, err = curErr, val = `local`)")
+                    Doc.str("(err = curErr, val = `local`)")
 
                 SymbolCont.Push(_) | SymbolCont.PushToParseTree(_) | SymbolCont.Ignore:
                     # Value of `try`. Symbol parser directly pushes to the vectors, or ignores, so
                     # we don't have a `val` field here.
-                    Doc.str("(cursor = cursor, err = curErr)")
+                    Doc.str("curErr")
 
             let doc = Doc.empty()
             if cont is SymbolCont.PushToParseTree(_):
@@ -800,7 +804,7 @@ generateSymbolParser(
                       4,
                       Doc.str("let symResult = try(||:")
                           + Doc.hardLine()
-                          + generateSymbolParser(symbol, terminalPats, cont)
+                          + generateSymbolParser(terminalType, symbol, terminalPats, cont)
                           + Doc.hardLine()
                           + resultDoc)
                  + Doc.hardLine()
@@ -819,20 +823,19 @@ generateSymbolParser(
                            + Doc.hardLine()
                            + Doc.nested(
                                4,
-                               Doc.str("Result.Ok(ok):")
+                               Doc.str("Result.Ok(newErr):")
                                    + Doc.hardLine()
                                    + okDoc))
 
         Symbol.Ignore(symbol):
-            generateSymbolParser(symbol, terminalPats, SymbolCont.Ignore)
+            generateSymbolParser(terminalType, symbol, terminalPats, SymbolCont.Ignore)
 
         Symbol.NegLookahead(symbol):
-            let doc = Doc.str("let tokensLen0 = tokens.len()") + Doc.hardLine()
-            doc + Doc.nested(
+            Doc.nested(
                 4,
                 Doc.str("let symResult = try(||:")
                     + Doc.hardLine()
-                    + generateSymbolParser(symbol, terminalPats, SymbolCont.Ignore))
+                    + generateSymbolParser(terminalType, symbol, terminalPats, SymbolCont.Ignore))
                 + Doc.hardLine()
                 + Doc.str(")")
                 + Doc.hardLine()
@@ -844,31 +847,35 @@ generateSymbolParser(
                             4,
                             Doc.str("Result.Err(err):")
                                 + Doc.hardLine()
-                                + makeUpdateError()
-                                + Doc.hardLine()
-                                + Doc.str("tokens.truncate(tokensLen0)"))
+                                + makeUpdateError())
                         + Doc.hardLine()
                         + Doc.nested(
                             4,
                             Doc.str("Result.Ok(_):")
                                 + Doc.hardLine()
-                                + makeThrow(makeUnexpectedTokenError())))
+                                + Doc.str("iter = iter0.clone()")
+                                + Doc.hardLine()
+                                + makeThrow(Doc.str("ParseError.takeAdvanced(curErr, ParseError(cursor = iter0.clone().next[iter, (idx: U32, token: `terminalType`), ParseError]().unwrap().idx))"))))
 
         Symbol.Bind(binder, symbol):
-            generateSymbolParser(symbol, terminalPats, SymbolCont.Bind(binder))
+            generateSymbolParser(terminalType, symbol, terminalPats, SymbolCont.Bind(binder))
 
         Symbol.EndOfInput:
             Doc.nested(
                 4,
-                Doc.str("if cursor == tokens.len():")
+                Doc.str("match iter.next[iter, (idx: U32, token: `terminalType`), ParseError]():")
                     + Doc.hardLine()
-                    + Doc.str("cursor"))
-                + Doc.hardLine()
-                + Doc.nested(
-                    4,
-                    Doc.str("else:")
-                        + Doc.hardLine()
-                        + makeThrow(makeUnexpectedTokenError()))
+                    + Doc.nested(
+                        4,
+                        Doc.str("Option.Some((idx, token)):")
+                            + Doc.hardLine()
+                            + makeThrow(Doc.str("ParseError.takeAdvanced(curErr, ParseError(cursor = idx))")))
+                    + Doc.hardLine()
+                    + Doc.nested(
+                        4,
+                        Doc.str("Option.None:")
+                            + Doc.hardLine()
+                            + Doc.str("U32.max()")))
 
         Symbol.Cursor:
             match cont:
@@ -913,10 +920,10 @@ tokensToCode(tokens: Vec[Token]) Str / exn:
     out.toStr()
 
 makeUnexpectedTokenError() Doc:
-    Doc.str("ParseError.takeAdvanced(curErr, ParseError(cursor = cursor))")
+    Doc.str("ParseError.takeAdvanced(curErr, ParseError(cursor = idx))")
 
 makeThrow(expr: Doc) Doc:
-    Doc.nested(4, Doc.str("throw(") + Doc.break_(0) + expr + Doc.char(')')).group()
+    Doc.str("throw(") + expr + Doc.char(')')
 
 # When generating code that backtracks, update the local `curErr: Option[ParseError]` if the new
 # error's cursor is more advanced than the current.

--- a/tools/peg/PegTestLib.fir
+++ b/tools/peg/PegTestLib.fir
@@ -14,10 +14,10 @@ impl ToStr[TestError]:
 
 
 runParser(
-        input: Str,
-        parseFn: Fn(Vec[Token], U32) (tree: tree, newCursor: U32, newErr: Option[ParseError]) / ParseError,
-        runScan: Bool,
-    ) tree / TestError:
+    input: Str,
+    parseFn: Fn(Enumerate[VecIter[Token]]) (tree: tree, newErr: Option[ParseError]) / ParseError,
+    runScan: Bool,
+) tree / TestError:
     let (tokens, error) = tokenize("<test input>", input)
 
     if error is Option.Some(error):
@@ -30,22 +30,26 @@ runParser(
             Result.Ok(tokens):
                 tokens
 
-    let result = match try(||: parseFn(tokens, 0)):
+    let tokenIter = tokens.iter()
+    let enumerate = tokenIter.enumerate[VecIter[Token], Token, ParseError, TestError]()
+
+    let result = match try(||: parseFn(enumerate)):
         Result.Err(err): throw(TestError.ParseError(err))
         Result.Ok(result): result
 
-    if result.newCursor != tokens.len():
-        throw(TestError.Other("parser didn't consume all input, input len = `tokens.len()`, cursor after parsing = `result.newCursor`"))
+    # TODO: Check `iter.next` here.
+    # if result.newCursor != tokens.len():
+    #     throw(TestError.Other("parser didn't consume all input, input len = `tokens.len()`, cursor after parsing = `result.newCursor`"))
 
     result.tree
 
 
 ## Print test name, run the given parser function on the input, print errors and trees.
 runTest[ToStr[nt]](
-        testName: Str,
-        input: Str,
-        parseFn: Fn(Vec[Token], U32) (tree: ParseTree[Token, nt], newCursor: U32, newErr: Option[ParseError]) / ParseError,
-    ) / exn:
+    testName: Str,
+    input: Str,
+    parseFn: Fn(Enumerate[VecIter[Token]]) (tree: ParseTree[Token, nt], newErr: Option[ParseError]) / ParseError,
+) / exn:
     print(testName)
     match try(||: runParser(input, parseFn, Bool.False)):
         Result.Ok(tree): print(tree.toDoc().render(80))
@@ -57,9 +61,9 @@ runTest[ToStr[nt]](
 ##
 ## Difference from `runTest` is that this prints the input, `runTest` prints the given test name.
 runTest_[ToStr[nt]](
-        input: Str,
-        parseFn: Fn(Vec[Token], U32) (tree: ParseTree[Token, nt], newCursor: U32, newErr: Option[ParseError]) / ParseError,
-    ) / exn:
+    input: Str,
+    parseFn: Fn(Enumerate[VecIter[Token]]) (tree: ParseTree[Token, nt], newErr: Option[ParseError]) / ParseError,
+) / exn:
     print(input)
     match try(||: runParser(input, parseFn, Bool.False)):
         Result.Ok(tree): print(tree.toDoc().render(80))
@@ -70,7 +74,7 @@ runTest_[ToStr[nt]](
 ## Same as `runTest_`, but runs scanner after lexer.
 runTestScanner_[ToStr[nt]](
         input: Str,
-        parseFn: Fn(Vec[Token], U32) (tree: ParseTree[Token, nt], newCursor: U32, newErr: Option[ParseError]) / ParseError,
+        parseFn: Fn(Enumerate[VecIter[Token]]) (tree: ParseTree[Token, nt], newErr: Option[ParseError]) / ParseError,
     ) / exn:
     print(input)
     match try(||: runParser(input, parseFn, Bool.True)):
@@ -81,7 +85,7 @@ runTestScanner_[ToStr[nt]](
 
 runTestIndent[ToStr[nt]](
         input: Str,
-        parseFn: Fn(Vec[Token], U32) (tree: ParseTree[Token, nt], newCursor: U32, newErr: Option[ParseError]) / ParseError,
+        parseFn: Fn(Enumerate[VecIter[Token]]) (tree: ParseTree[Token, nt], newErr: Option[ParseError]) / ParseError,
     ) Bool / exn:
     print(input)
     let result = match try(||: runParser(input, parseFn, Bool.True)):

--- a/tools/peg/PegTestLib.fir
+++ b/tools/peg/PegTestLib.fir
@@ -73,9 +73,9 @@ runTest_[ToStr[nt]](
 
 ## Same as `runTest_`, but runs scanner after lexer.
 runTestScanner_[ToStr[nt]](
-        input: Str,
-        parseFn: Fn(Enumerate[VecIter[Token]]) (tree: ParseTree[Token, nt], newErr: Option[ParseError]) / ParseError,
-    ) / exn:
+    input: Str,
+    parseFn: Fn(Enumerate[VecIter[Token]]) (tree: ParseTree[Token, nt], newErr: Option[ParseError]) / ParseError,
+) / exn:
     print(input)
     match try(||: runParser(input, parseFn, Bool.True)):
         Result.Ok(tree): print(tree.toDoc().render(80))
@@ -84,9 +84,9 @@ runTestScanner_[ToStr[nt]](
 
 
 runTestIndent[ToStr[nt]](
-        input: Str,
-        parseFn: Fn(Enumerate[VecIter[Token]]) (tree: ParseTree[Token, nt], newErr: Option[ParseError]) / ParseError,
-    ) Bool / exn:
+    input: Str,
+    parseFn: Fn(Enumerate[VecIter[Token]]) (tree: ParseTree[Token, nt], newErr: Option[ParseError]) / ParseError,
+) Bool / exn:
     print(input)
     let result = match try(||: runParser(input, parseFn, Bool.True)):
         Result.Ok(tree):

--- a/tools/peg/TestGrammar.fir
+++ b/tools/peg/TestGrammar.fir
@@ -300,14 +300,14 @@ zeroOrOneAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
                         throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
                 Option.None:
                     throw(ParseError(cursor = U32.max()))
-            curErr
+            (err = curErr)
         )
         match symResult:
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 nodes.truncate(nodesLen0)
-            Result.Ok(newErr):
-                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+            Result.Ok(ok):
+                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
         match iter.next():
             Option.Some((idx, token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
@@ -738,7 +738,7 @@ semanticActionGroup[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
-        match iter.next():
+        let a = match iter.next():
             Option.Some((idx, token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     token
@@ -746,7 +746,7 @@ semanticActionGroup[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
-        match iter.next():
+        let b = match iter.next():
             Option.Some((idx, token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     token
@@ -781,7 +781,7 @@ semanticActionOptional[Iterator[iter, (idx: U32, token: Token), ParseError], Clo
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let symResult = try(||:
-            match iter.next():
+            let cs = match iter.next():
                 Option.Some((idx, token)):
                     if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                         token
@@ -795,8 +795,8 @@ semanticActionOptional[Iterator[iter, (idx: U32, token: Token), ParseError], Clo
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 Option.None
-            Result.Ok(newErr):
-                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+            Result.Ok(ok):
+                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
                 Option.Some(ok.val)
         match iter.next[iter, (idx: U32, token: Token), ParseError]():
             Option.Some((idx, token)):
@@ -874,7 +874,7 @@ semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
                 Result.Ok(newErr):
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         let symResult = try(||:
-            match iter.next():
+            let cOpt = match iter.next():
                 Option.Some((idx, token)):
                     if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                         token
@@ -888,8 +888,8 @@ semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 Option.None
-            Result.Ok(newErr):
-                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+            Result.Ok(ok):
+                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
                 Option.Some(ok.val)
         let group = (aVec = aVec, bVec = bVec, cOpt = cOpt)
         match iter.next[iter, (idx: U32, token: Token), ParseError]():
@@ -913,6 +913,7 @@ cursorPositions[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
+        let cursor = iter.next[iter, (idx: U32, token: Token), ParseError]().map(|item: (idx: U32, token: Token)|: item.idx).unwrapOr(U32.max())
         let c0 = cursor
         match iter.next():
             Option.Some((idx, token)):
@@ -922,6 +923,7 @@ cursorPositions[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
+        let cursor = iter.next[iter, (idx: U32, token: Token), ParseError]().map(|item: (idx: U32, token: Token)|: item.idx).unwrapOr(U32.max())
         let c1 = cursor
         match iter.next():
             Option.Some((idx, token)):
@@ -931,6 +933,7 @@ cursorPositions[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
+        let cursor = iter.next[iter, (idx: U32, token: Token), ParseError]().map(|item: (idx: U32, token: Token)|: item.idx).unwrapOr(U32.max())
         let c2 = cursor
         match iter.next():
             Option.Some((idx, token)):
@@ -940,6 +943,7 @@ cursorPositions[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
+        let cursor = iter.next[iter, (idx: U32, token: Token), ParseError]().map(|item: (idx: U32, token: Token)|: item.idx).unwrapOr(U32.max())
         let c3 = cursor
         let value = do:
             let vec: Vec[U32] = Vec.[c0, c1, c2, c3]
@@ -974,7 +978,7 @@ simpleGroup1[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
-        match iter.next():
+        let x = match iter.next():
             Option.Some((idx, token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     token
@@ -1031,7 +1035,7 @@ simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         let symResult = try(||:
-            match iter.next():
+            let x = match iter.next():
                 Option.Some((idx, token)):
                     if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                         token
@@ -1045,8 +1049,8 @@ simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 Option.None
-            Result.Ok(newErr):
-                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+            Result.Ok(ok):
+                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
                 Option.Some(ok.val)
         match iter.next():
             Option.Some((idx, token)):
@@ -1239,7 +1243,7 @@ simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                         throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
                 Option.None:
                     throw(ParseError(cursor = U32.max()))
-            match iter.next():
+            let x = match iter.next():
                 Option.Some((idx, token)):
                     if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                         token
@@ -1261,8 +1265,8 @@ simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 Option.None
-            Result.Ok(newErr):
-                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+            Result.Ok(ok):
+                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
                 Option.Some(ok.val)
         match iter.next():
             Option.Some((idx, token)):

--- a/tools/peg/TestGrammar.fir
+++ b/tools/peg/TestGrammar.fir
@@ -59,1146 +59,1385 @@ impl Eq[NonTerminal]:
             (left = NonTerminal.BracketedOneOrMoreA, right = NonTerminal.BracketedOneOrMoreA): Bool.True
             _: Bool.False
 
-terminalA(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+terminalA[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.TerminalA, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-terminalB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+terminalB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.TerminalB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-terminalAOrB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+terminalAOrB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.TerminalAOrB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.TerminalAOrB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-terminalAThenB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+terminalAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.TerminalAThenB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-zeroOrMoreAThenB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+zeroOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         loop:
             let nodesLen0 = nodes.len()
             let symResult = try(||:
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                    nodes.push(ParseTree.Terminal(sym))
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                (cursor = cursor, err = curErr)
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                            nodes.push(ParseTree.Terminal(token))
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     nodes.truncate(nodesLen0)
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.ZeroOrMoreAThenB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-oneOrMoreAThenB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+oneOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         loop:
             let nodesLen0 = nodes.len()
             let symResult = try(||:
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                    nodes.push(ParseTree.Terminal(sym))
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                (cursor = cursor, err = curErr)
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                            nodes.push(ParseTree.Terminal(token))
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     nodes.truncate(nodesLen0)
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.OneOrMoreAThenB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-zeroOrOneAThenB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+zeroOrOneAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         let nodesLen0 = nodes.len()
         let symResult = try(||:
-            if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                nodes.push(ParseTree.Terminal(sym))
-                cursor += 1
-            else:
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-            (cursor = cursor, err = curErr)
+            match iter.next():
+                Option.Some((idx, token)):
+                    if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                        nodes.push(ParseTree.Terminal(token))
+                    else:
+                        throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                Option.None:
+                    throw(ParseError(cursor = U32.max()))
+            curErr
         )
         match symResult:
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 nodes.truncate(nodesLen0)
-            Result.Ok(ok):
-                cursor = ok.cursor
-                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            Result.Ok(newErr):
+                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.ZeroOrOneAThenB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-ignoreAThenB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+ignoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.IgnoreAThenB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-ignoreAThenIgnoreB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+ignoreAThenIgnoreB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.IgnoreAThenIgnoreB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-ignoreGroupAThenB(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+ignoreGroupAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.IgnoreGroupAThenB, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-nonTerminals(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+nonTerminals[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        let nonTerminalResult = terminalAOrB(tokens, cursor)
-        cursor = nonTerminalResult.newCursor
+        let nonTerminalResult = terminalAOrB(iter)
         curErr = nonTerminalResult.newErr
         nodes.push(nonTerminalResult.tree)
-        let nonTerminalResult = terminalAOrB(tokens, cursor)
-        cursor = nonTerminalResult.newCursor
+        let nonTerminalResult = terminalAOrB(iter)
         curErr = nonTerminalResult.newErr
         nodes.push(nonTerminalResult.tree)
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.NonTerminals, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-nonTerminalsBacktrack(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+nonTerminalsBacktrack[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        let nonTerminalResult = terminalAOrB(tokens, cursor)
-        cursor = nonTerminalResult.newCursor
+        let nonTerminalResult = terminalAOrB(iter)
         curErr = nonTerminalResult.newErr
         nodes.push(nonTerminalResult.tree)
-        let nonTerminalResult = terminalAOrB(tokens, cursor)
-        cursor = nonTerminalResult.newCursor
+        let nonTerminalResult = terminalAOrB(iter)
         curErr = nonTerminalResult.newErr
         nodes.push(nonTerminalResult.tree)
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.NonTerminalsBacktrack, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.NonTerminalsBacktrack, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-negLookahead(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+negLookahead[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        let tokensLen0 = tokens.len()
         let symResult = try(||:
-            if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                cursor += 1
-            else:
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            match iter.next():
+                Option.Some((idx, token)):
+                    if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                        ()
+                    else:
+                        throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                Option.None:
+                    throw(ParseError(cursor = U32.max()))
         )
         match symResult:
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-                tokens.truncate(tokensLen0)
             Result.Ok(_):
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        let nonTerminalResult = terminalAOrB(tokens, cursor)
-        cursor = nonTerminalResult.newCursor
+                iter = iter0.clone()
+                throw(ParseError.takeAdvanced(curErr, ParseError(cursor = iter0.clone().next[iter, (idx: U32, token: Token), ParseError]().unwrap().idx)))
+        let nonTerminalResult = terminalAOrB(iter)
         curErr = nonTerminalResult.newErr
         nodes.push(nonTerminalResult.tree)
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.NegLookahead, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-endOfInputTest(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+endOfInputTest[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            nodes.push(ParseTree.Terminal(sym))
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if cursor == tokens.len():
-            cursor
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    nodes.push(ParseTree.Terminal(token))
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next[iter, (idx: U32, token: Token), ParseError]():
+            Option.Some((idx, token)):
+                throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                U32.max()
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.EndOfInputTest, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-bracketedOneOrMoreA(tokens: Vec[Token], cursor: U32) (tree: ParseTree[Token, NonTerminal], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+bracketedOneOrMoreA[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         loop:
             let nodesLen0 = nodes.len()
             let symResult = try(||:
-                let nonTerminalResult = oneOrMoreAThenB(tokens, cursor)
-                cursor = nonTerminalResult.newCursor
+                let nonTerminalResult = oneOrMoreAThenB(iter)
                 curErr = nonTerminalResult.newErr
                 nodes.push(nonTerminalResult.tree)
-                (cursor = cursor, err = curErr)
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     nodes.truncate(nodesLen0)
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
-        if cursor == tokens.len():
-            cursor
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+        match iter.next[iter, (idx: U32, token: Token), ParseError]():
+            Option.Some((idx, token)):
+                throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                U32.max()
         let value = do:
             ParseTree.NonTerminal(kind = NonTerminal.BracketedOneOrMoreA, nodes)
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-semanticActionSimple(tokens: Vec[Token], cursor: U32) (tree: Char, newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+semanticActionSimple[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Char, newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             'a'
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             'b'
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-semanticActionZeroOrMore(tokens: Vec[Token], cursor: U32) (tree: Vec[Char], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+semanticActionZeroOrMore[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Char], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let cs = Vec.empty()
         loop:
             let symResult = try(||:
-                let nonTerminalResult = semanticActionSimple(tokens, cursor)
-                cursor = nonTerminalResult.newCursor
+                let nonTerminalResult = semanticActionSimple(iter)
                 curErr = nonTerminalResult.newErr
                 cs.push(nonTerminalResult.tree)
-                (cursor = cursor, err = curErr)
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         let value = do:
             cs
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-semanticActionOneOrMore(tokens: Vec[Token], cursor: U32) (tree: Vec[Char], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+semanticActionOneOrMore[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Char], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let cs = Vec.empty()
-        let nonTerminalResult = semanticActionSimple(tokens, cursor)
-        cursor = nonTerminalResult.newCursor
+        let nonTerminalResult = semanticActionSimple(iter)
         curErr = nonTerminalResult.newErr
         cs.push(nonTerminalResult.tree)
         loop:
             let symResult = try(||:
-                let nonTerminalResult = semanticActionSimple(tokens, cursor)
-                cursor = nonTerminalResult.newCursor
+                let nonTerminalResult = semanticActionSimple(iter)
                 curErr = nonTerminalResult.newErr
                 cs.push(nonTerminalResult.tree)
-                (cursor = cursor, err = curErr)
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         let value = do:
             cs
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-semanticActionGroup(tokens: Vec[Token], cursor: U32) (tree: Vec[Str], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+semanticActionGroup[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Str], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        let a = if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-            sym
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        let b = if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            cursor += 1
-            sym
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    token
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    token
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let ab = (a = a, b = b)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             let strs: Vec[Str] = Vec.[ab.a.text, ab.b.text]
             strs
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-semanticActionOptional(tokens: Vec[Token], cursor: U32) (tree: Option[Token], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+semanticActionOptional[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let symResult = try(||:
-            let cs = if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                cursor += 1
-                sym
-            else:
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-            (cursor = cursor, err = curErr, val = cs)
+            match iter.next():
+                Option.Some((idx, token)):
+                    if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                        token
+                    else:
+                        throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                Option.None:
+                    throw(ParseError(cursor = U32.max()))
+            (err = curErr, val = cs)
         )
         let cs = match symResult:
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 Option.None
-            Result.Ok(ok):
-                cursor = ok.cursor
-                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
+            Result.Ok(newErr):
+                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
                 Option.Some(ok.val)
-        if cursor == tokens.len():
-            cursor
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next[iter, (idx: U32, token: Token), ParseError]():
+            Option.Some((idx, token)):
+                throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                U32.max()
         let value = do:
             cs
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-semanticActionComplex(tokens: Vec[Token], cursor: U32) (tree: (aVec: Vec[Token], bVec: Vec[Token], cOpt: Option[Token]), newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: (aVec: Vec[Token], bVec: Vec[Token], cOpt: Option[Token]), newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let aVec = Vec.empty()
         loop:
             let symResult = try(||:
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                    aVec.push(sym)
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                (cursor = cursor, err = curErr)
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                            aVec.push(token)
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         let bVec = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            bVec.push(sym)
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    bVec.push(token)
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         loop:
             let symResult = try(||:
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-                    bVec.push(sym)
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                (cursor = cursor, err = curErr)
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                            bVec.push(token)
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         let symResult = try(||:
-            let cOpt = if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-                cursor += 1
-                sym
-            else:
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-            (cursor = cursor, err = curErr, val = cOpt)
+            match iter.next():
+                Option.Some((idx, token)):
+                    if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                        token
+                    else:
+                        throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                Option.None:
+                    throw(ParseError(cursor = U32.max()))
+            (err = curErr, val = cOpt)
         )
         let cOpt = match symResult:
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 Option.None
-            Result.Ok(ok):
-                cursor = ok.cursor
-                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
+            Result.Ok(newErr):
+                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
                 Option.Some(ok.val)
         let group = (aVec = aVec, bVec = bVec, cOpt = cOpt)
-        if cursor == tokens.len():
-            cursor
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next[iter, (idx: U32, token: Token), ParseError]():
+            Option.Some((idx, token)):
+                throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                U32.max()
         let value = do:
             group
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-cursorPositions(tokens: Vec[Token], cursor: U32) (tree: Vec[U32], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+cursorPositions[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[U32], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let c0 = cursor
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let c1 = cursor
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let c2 = cursor
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let c3 = cursor
         let value = do:
             let vec: Vec[U32] = Vec.[c0, c1, c2, c3]
             vec
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-simpleGroup1(tokens: Vec[Token], cursor: U32) (tree: Token, newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+simpleGroup1[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Token, newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        let x = if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            cursor += 1
-            sym
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    token
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             x
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-simpleGroup2(tokens: Vec[Token], cursor: U32) (tree: Option[Token], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let symResult = try(||:
-            let x = if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-                cursor += 1
-                sym
-            else:
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-            (cursor = cursor, err = curErr, val = x)
+            match iter.next():
+                Option.Some((idx, token)):
+                    if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                        token
+                    else:
+                        throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                Option.None:
+                    throw(ParseError(cursor = U32.max()))
+            (err = curErr, val = x)
         )
         let x = match symResult:
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 Option.None
-            Result.Ok(ok):
-                cursor = ok.cursor
-                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
+            Result.Ok(newErr):
+                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
                 Option.Some(ok.val)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             x
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-simpleGroup3(tokens: Vec[Token], cursor: U32) (tree: Vec[Token], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+simpleGroup3[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let x = Vec.empty()
         loop:
             let symResult = try(||:
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-                    x.push(sym)
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                (cursor = cursor, err = curErr)
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                            x.push(token)
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             x
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-simpleGroup4(tokens: Vec[Token], cursor: U32) (tree: Vec[Token], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+simpleGroup4[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let x = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            x.push(sym)
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    x.push(token)
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         loop:
             let symResult = try(||:
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-                    x.push(sym)
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                (cursor = cursor, err = curErr)
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                            x.push(token)
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             x
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-simpleGroup5(tokens: Vec[Token], cursor: U32) (tree: Option[Token], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let symResult = try(||:
-            if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                cursor += 1
-            else:
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-            let x = if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-                cursor += 1
-                sym
-            else:
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-            if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-                cursor += 1
-            else:
-                throw(
-                    ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-            (cursor = cursor, err = curErr, val = x)
+            match iter.next():
+                Option.Some((idx, token)):
+                    if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                        ()
+                    else:
+                        throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                Option.None:
+                    throw(ParseError(cursor = U32.max()))
+            match iter.next():
+                Option.Some((idx, token)):
+                    if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                        token
+                    else:
+                        throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                Option.None:
+                    throw(ParseError(cursor = U32.max()))
+            match iter.next():
+                Option.Some((idx, token)):
+                    if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                        ()
+                    else:
+                        throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                Option.None:
+                    throw(ParseError(cursor = U32.max()))
+            (err = curErr, val = x)
         )
         let x = match symResult:
             Result.Err(err):
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                 Option.None
-            Result.Ok(ok):
-                cursor = ok.cursor
-                curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
+            Result.Ok(newErr):
+                curErr = ParseError.takeAdvancedOpt(curErr, newErr)
                 Option.Some(ok.val)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             x
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-simpleGroup6(tokens: Vec[Token], cursor: U32) (tree: Vec[Token], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+simpleGroup6[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let x = Vec.empty()
         loop:
             let symResult = try(||:
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-                    x.push(sym)
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                (cursor = cursor, err = curErr)
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                            ()
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                            x.push(token)
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                            ()
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             x
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())
 
-simpleGroup7(tokens: Vec[Token], cursor: U32) (tree: Vec[Token], newCursor: U32, newErr: Option[ParseError]) / ParseError:
-    let cursor0 = cursor
+simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
+    let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let x = Vec.empty()
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-            x.push(sym)
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                    x.push(token)
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         loop:
             let symResult = try(||:
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "a", ..):
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "b", ..):
-                    x.push(sym)
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-                    cursor += 1
-                else:
-                    throw(
-                        ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
-                (cursor = cursor, err = curErr)
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "a", ..):
+                            ()
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "b", ..):
+                            x.push(token)
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                match iter.next():
+                    Option.Some((idx, token)):
+                        if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                            ()
+                        else:
+                            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+                    Option.None:
+                        throw(ParseError(cursor = U32.max()))
+                curErr
             )
             match symResult:
                 Result.Err(err):
                     curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
                     break
-                Result.Ok(ok):
-                    cursor = ok.cursor
-                    curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
-        if tokens.getOpt(cursor) is Option.Some(sym) and sym is Token(kind = TokenKind.LowerId, text = "c", ..):
-            cursor += 1
-        else:
-            throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+                Result.Ok(newErr):
+                    curErr = ParseError.takeAdvancedOpt(curErr, newErr)
+        match iter.next():
+            Option.Some((idx, token)):
+                if token is Token(kind = TokenKind.LowerId, text = "c", ..):
+                    ()
+                else:
+                    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
+            Option.None:
+                throw(ParseError(cursor = U32.max()))
         let value = do:
             x
-        (value = value, cursor = cursor, err = curErr)
+        (value = value, err = curErr)
     )
     match altResult:
         Result.Err(err):
             curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
-            cursor = cursor0
-        Result.Ok((value = value, cursor = newCursor, err = newErr)):
-            return (tree = value, newCursor = newCursor, newErr = newErr)
-    throw(ParseError.takeAdvanced(curErr, ParseError(cursor = cursor)))
+            iter = iter0.clone()
+        Result.Ok((value = value, err = newErr)):
+            return (tree = value, newErr = newErr)
+    throw(curErr.unwrap())

--- a/tools/peg/TestGrammar.fir
+++ b/tools/peg/TestGrammar.fir
@@ -59,13 +59,13 @@ impl Eq[NonTerminal]:
             (left = NonTerminal.BracketedOneOrMoreA, right = NonTerminal.BracketedOneOrMoreA): Bool.True
             _: Bool.False
 
-terminalA[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+terminalA[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -84,13 +84,13 @@ terminalA[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](ite
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-terminalB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+terminalB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -109,13 +109,13 @@ terminalB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](ite
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-terminalAOrB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+terminalAOrB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -135,7 +135,7 @@ terminalAOrB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -154,13 +154,13 @@ terminalAOrB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-terminalAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+terminalAThenB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -168,7 +168,7 @@ terminalAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -187,7 +187,7 @@ terminalAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-zeroOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+zeroOrMoreAThenB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
@@ -196,7 +196,7 @@ zeroOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[ite
             let nodesLen0 = nodes.len()
             let symResult = try(||:
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                             nodes.push(ParseTree.Terminal(token))
                         else:
@@ -213,7 +213,7 @@ zeroOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[ite
                 Result.Ok(newErr):
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -232,13 +232,13 @@ zeroOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[ite
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-oneOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+oneOrMoreAThenB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -249,7 +249,7 @@ oneOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
             let nodesLen0 = nodes.len()
             let symResult = try(||:
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                             nodes.push(ParseTree.Terminal(token))
                         else:
@@ -266,7 +266,7 @@ oneOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
                 Result.Ok(newErr):
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -285,7 +285,7 @@ oneOrMoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-zeroOrOneAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+zeroOrOneAThenB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
@@ -293,7 +293,7 @@ zeroOrOneAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
         let nodesLen0 = nodes.len()
         let symResult = try(||:
             match iter.next():
-                Option.Some((idx, token)):
+                Option.Some((idx, item = token)):
                     if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                         nodes.push(ParseTree.Terminal(token))
                     else:
@@ -309,7 +309,7 @@ zeroOrOneAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
             Result.Ok(ok):
                 curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -328,13 +328,13 @@ zeroOrOneAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-ignoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+ignoreAThenB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -342,7 +342,7 @@ ignoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -361,13 +361,13 @@ ignoreAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-ignoreAThenIgnoreB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+ignoreAThenIgnoreB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -375,7 +375,7 @@ ignoreAThenIgnoreB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[i
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     ()
                 else:
@@ -394,13 +394,13 @@ ignoreAThenIgnoreB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[i
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-ignoreGroupAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+ignoreGroupAThenB[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -408,7 +408,7 @@ ignoreGroupAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[it
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     ()
                 else:
@@ -427,7 +427,7 @@ ignoreGroupAThenB[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[it
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-nonTerminals[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+nonTerminals[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
@@ -450,7 +450,7 @@ nonTerminals[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-nonTerminalsBacktrack[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+nonTerminalsBacktrack[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
@@ -474,7 +474,7 @@ nonTerminalsBacktrack[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -482,7 +482,7 @@ nonTerminalsBacktrack[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -501,14 +501,14 @@ nonTerminalsBacktrack[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-negLookahead[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+negLookahead[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         let symResult = try(||:
             match iter.next():
-                Option.Some((idx, token)):
+                Option.Some((idx, item = token)):
                     if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                         ()
                     else:
@@ -521,7 +521,7 @@ negLookahead[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 curErr = Option.Some(ParseError.takeAdvanced(curErr, err))
             Result.Ok(_):
                 iter = iter0.clone()
-                throw(ParseError.takeAdvanced(curErr, ParseError(cursor = iter0.clone().next[iter, (idx: U32, token: Token), ParseError]().unwrap().idx)))
+                throw(ParseError.takeAdvanced(curErr, ParseError(cursor = iter0.clone().next[iter, (idx: U32, item: Token), ParseError]().unwrap().idx)))
         let nonTerminalResult = terminalAOrB(iter)
         curErr = nonTerminalResult.newErr
         nodes.push(nonTerminalResult.tree)
@@ -537,13 +537,13 @@ negLookahead[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-endOfInputTest[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+endOfInputTest[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
@@ -551,15 +551,15 @@ endOfInputTest[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     nodes.push(ParseTree.Terminal(token))
                 else:
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
-        match iter.next[iter, (idx: U32, token: Token), ParseError]():
-            Option.Some((idx, token)):
+        match iter.next[iter, (idx: U32, item: Token), ParseError]():
+            Option.Some((idx, item = token)):
                 throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 U32.max()
@@ -575,13 +575,13 @@ endOfInputTest[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-bracketedOneOrMoreA[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
+bracketedOneOrMoreA[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: ParseTree[Token, NonTerminal], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let nodes: Vec[ParseTree[Token, NonTerminal]] = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     ()
                 else:
@@ -603,8 +603,8 @@ bracketedOneOrMoreA[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[
                     break
                 Result.Ok(newErr):
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
-        match iter.next[iter, (idx: U32, token: Token), ParseError]():
-            Option.Some((idx, token)):
+        match iter.next[iter, (idx: U32, item: Token), ParseError]():
+            Option.Some((idx, item = token)):
                 throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 U32.max()
@@ -620,12 +620,12 @@ bracketedOneOrMoreA[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-semanticActionSimple[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Char, newErr: Option[ParseError]) / ParseError:
+semanticActionSimple[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Char, newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -644,7 +644,7 @@ semanticActionSimple[Iterator[iter, (idx: U32, token: Token), ParseError], Clone
             return (tree = value, newErr = newErr)
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     ()
                 else:
@@ -663,7 +663,7 @@ semanticActionSimple[Iterator[iter, (idx: U32, token: Token), ParseError], Clone
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-semanticActionZeroOrMore[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Char], newErr: Option[ParseError]) / ParseError:
+semanticActionZeroOrMore[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Char], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
@@ -693,7 +693,7 @@ semanticActionZeroOrMore[Iterator[iter, (idx: U32, token: Token), ParseError], C
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-semanticActionOneOrMore[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Char], newErr: Option[ParseError]) / ParseError:
+semanticActionOneOrMore[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Char], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
@@ -726,12 +726,12 @@ semanticActionOneOrMore[Iterator[iter, (idx: U32, token: Token), ParseError], Cl
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-semanticActionGroup[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Str], newErr: Option[ParseError]) / ParseError:
+semanticActionGroup[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Str], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -739,7 +739,7 @@ semanticActionGroup[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         let a = match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     token
                 else:
@@ -747,7 +747,7 @@ semanticActionGroup[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         let b = match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     token
                 else:
@@ -756,7 +756,7 @@ semanticActionGroup[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[
                 throw(ParseError(cursor = U32.max()))
         let ab = (a = a, b = b)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     ()
                 else:
@@ -776,13 +776,13 @@ semanticActionGroup[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-semanticActionOptional[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
+semanticActionOptional[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         let symResult = try(||:
             let cs = match iter.next():
-                Option.Some((idx, token)):
+                Option.Some((idx, item = token)):
                     if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                         token
                     else:
@@ -798,8 +798,8 @@ semanticActionOptional[Iterator[iter, (idx: U32, token: Token), ParseError], Clo
             Result.Ok(ok):
                 curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
                 Option.Some(ok.val)
-        match iter.next[iter, (idx: U32, token: Token), ParseError]():
-            Option.Some((idx, token)):
+        match iter.next[iter, (idx: U32, item: Token), ParseError]():
+            Option.Some((idx, item = token)):
                 throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 U32.max()
@@ -815,12 +815,12 @@ semanticActionOptional[Iterator[iter, (idx: U32, token: Token), ParseError], Clo
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: (aVec: Vec[Token], bVec: Vec[Token], cOpt: Option[Token]), newErr: Option[ParseError]) / ParseError:
+semanticActionComplex[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: (aVec: Vec[Token], bVec: Vec[Token], cOpt: Option[Token]), newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -831,7 +831,7 @@ semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
         loop:
             let symResult = try(||:
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                             aVec.push(token)
                         else:
@@ -848,7 +848,7 @@ semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         let bVec = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     bVec.push(token)
                 else:
@@ -858,7 +858,7 @@ semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
         loop:
             let symResult = try(||:
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                             bVec.push(token)
                         else:
@@ -875,7 +875,7 @@ semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         let symResult = try(||:
             let cOpt = match iter.next():
-                Option.Some((idx, token)):
+                Option.Some((idx, item = token)):
                     if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                         token
                     else:
@@ -892,8 +892,8 @@ semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
                 curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
                 Option.Some(ok.val)
         let group = (aVec = aVec, bVec = bVec, cOpt = cOpt)
-        match iter.next[iter, (idx: U32, token: Token), ParseError]():
-            Option.Some((idx, token)):
+        match iter.next[iter, (idx: U32, item: Token), ParseError]():
+            Option.Some((idx, item = token)):
                 throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 U32.max()
@@ -909,41 +909,41 @@ semanticActionComplex[Iterator[iter, (idx: U32, token: Token), ParseError], Clon
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-cursorPositions[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[U32], newErr: Option[ParseError]) / ParseError:
+cursorPositions[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[U32], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
-        let cursor = iter.next[iter, (idx: U32, token: Token), ParseError]().map(|item: (idx: U32, token: Token)|: item.idx).unwrapOr(U32.max())
+        let cursor = iter.next[iter, (idx: U32, item: Token), ParseError]().map(|item: (idx: U32, item: Token)|: item.idx).unwrapOr(U32.max())
         let c0 = cursor
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
-        let cursor = iter.next[iter, (idx: U32, token: Token), ParseError]().map(|item: (idx: U32, token: Token)|: item.idx).unwrapOr(U32.max())
+        let cursor = iter.next[iter, (idx: U32, item: Token), ParseError]().map(|item: (idx: U32, item: Token)|: item.idx).unwrapOr(U32.max())
         let c1 = cursor
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     ()
                 else:
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
-        let cursor = iter.next[iter, (idx: U32, token: Token), ParseError]().map(|item: (idx: U32, token: Token)|: item.idx).unwrapOr(U32.max())
+        let cursor = iter.next[iter, (idx: U32, item: Token), ParseError]().map(|item: (idx: U32, item: Token)|: item.idx).unwrapOr(U32.max())
         let c2 = cursor
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
                     throw(ParseError.takeAdvanced(curErr, ParseError(cursor = idx)))
             Option.None:
                 throw(ParseError(cursor = U32.max()))
-        let cursor = iter.next[iter, (idx: U32, token: Token), ParseError]().map(|item: (idx: U32, token: Token)|: item.idx).unwrapOr(U32.max())
+        let cursor = iter.next[iter, (idx: U32, item: Token), ParseError]().map(|item: (idx: U32, item: Token)|: item.idx).unwrapOr(U32.max())
         let c3 = cursor
         let value = do:
             let vec: Vec[U32] = Vec.[c0, c1, c2, c3]
@@ -958,12 +958,12 @@ cursorPositions[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-simpleGroup1[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Token, newErr: Option[ParseError]) / ParseError:
+simpleGroup1[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Token, newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -971,7 +971,7 @@ simpleGroup1[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -979,7 +979,7 @@ simpleGroup1[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         let x = match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     token
                 else:
@@ -987,7 +987,7 @@ simpleGroup1[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -995,7 +995,7 @@ simpleGroup1[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1014,12 +1014,12 @@ simpleGroup1[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
+simpleGroup2[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1027,7 +1027,7 @@ simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1036,7 +1036,7 @@ simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 throw(ParseError(cursor = U32.max()))
         let symResult = try(||:
             let x = match iter.next():
-                Option.Some((idx, token)):
+                Option.Some((idx, item = token)):
                     if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                         token
                     else:
@@ -1053,7 +1053,7 @@ simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
                 Option.Some(ok.val)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1061,7 +1061,7 @@ simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1080,12 +1080,12 @@ simpleGroup2[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-simpleGroup3[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
+simpleGroup3[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1093,7 +1093,7 @@ simpleGroup3[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1104,7 +1104,7 @@ simpleGroup3[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
         loop:
             let symResult = try(||:
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                             x.push(token)
                         else:
@@ -1120,7 +1120,7 @@ simpleGroup3[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 Result.Ok(newErr):
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1128,7 +1128,7 @@ simpleGroup3[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1147,12 +1147,12 @@ simpleGroup3[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-simpleGroup4[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
+simpleGroup4[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1160,7 +1160,7 @@ simpleGroup4[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1169,7 +1169,7 @@ simpleGroup4[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 throw(ParseError(cursor = U32.max()))
         let x = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     x.push(token)
                 else:
@@ -1179,7 +1179,7 @@ simpleGroup4[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
         loop:
             let symResult = try(||:
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                             x.push(token)
                         else:
@@ -1195,7 +1195,7 @@ simpleGroup4[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 Result.Ok(newErr):
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1203,7 +1203,7 @@ simpleGroup4[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1222,12 +1222,12 @@ simpleGroup4[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
+simpleGroup5[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Option[Token], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1236,7 +1236,7 @@ simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 throw(ParseError(cursor = U32.max()))
         let symResult = try(||:
             match iter.next():
-                Option.Some((idx, token)):
+                Option.Some((idx, item = token)):
                     if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                         ()
                     else:
@@ -1244,7 +1244,7 @@ simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 Option.None:
                     throw(ParseError(cursor = U32.max()))
             let x = match iter.next():
-                Option.Some((idx, token)):
+                Option.Some((idx, item = token)):
                     if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                         token
                     else:
@@ -1252,7 +1252,7 @@ simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 Option.None:
                     throw(ParseError(cursor = U32.max()))
             match iter.next():
-                Option.Some((idx, token)):
+                Option.Some((idx, item = token)):
                     if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                         ()
                     else:
@@ -1269,7 +1269,7 @@ simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 curErr = ParseError.takeAdvancedOpt(curErr, ok.err)
                 Option.Some(ok.val)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1288,12 +1288,12 @@ simpleGroup5[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-simpleGroup6[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
+simpleGroup6[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1304,7 +1304,7 @@ simpleGroup6[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
         loop:
             let symResult = try(||:
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                             ()
                         else:
@@ -1312,7 +1312,7 @@ simpleGroup6[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                     Option.None:
                         throw(ParseError(cursor = U32.max()))
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                             x.push(token)
                         else:
@@ -1320,7 +1320,7 @@ simpleGroup6[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                     Option.None:
                         throw(ParseError(cursor = U32.max()))
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                             ()
                         else:
@@ -1336,7 +1336,7 @@ simpleGroup6[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 Result.Ok(newErr):
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1355,12 +1355,12 @@ simpleGroup6[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             return (tree = value, newErr = newErr)
     throw(curErr.unwrap())
 
-simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
+simpleGroup7[Iterator[iter, (idx: U32, item: Token), ParseError], Clone[iter]](iter: iter) (tree: Vec[Token], newErr: Option[ParseError]) / ParseError:
     let iter0 = iter.clone()
     let curErr: Option[ParseError] = Option.None
     let altResult = try(||:
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1369,7 +1369,7 @@ simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 throw(ParseError(cursor = U32.max()))
         let x = Vec.empty()
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                     ()
                 else:
@@ -1377,7 +1377,7 @@ simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                     x.push(token)
                 else:
@@ -1385,7 +1385,7 @@ simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
             Option.None:
                 throw(ParseError(cursor = U32.max()))
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:
@@ -1395,7 +1395,7 @@ simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
         loop:
             let symResult = try(||:
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "a", ..):
                             ()
                         else:
@@ -1403,7 +1403,7 @@ simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                     Option.None:
                         throw(ParseError(cursor = U32.max()))
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "b", ..):
                             x.push(token)
                         else:
@@ -1411,7 +1411,7 @@ simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                     Option.None:
                         throw(ParseError(cursor = U32.max()))
                 match iter.next():
-                    Option.Some((idx, token)):
+                    Option.Some((idx, item = token)):
                         if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                             ()
                         else:
@@ -1427,7 +1427,7 @@ simpleGroup7[Iterator[iter, (idx: U32, token: Token), ParseError], Clone[iter]](
                 Result.Ok(newErr):
                     curErr = ParseError.takeAdvancedOpt(curErr, newErr)
         match iter.next():
-            Option.Some((idx, token)):
+            Option.Some((idx, item = token)):
                 if token is Token(kind = TokenKind.LowerId, text = "c", ..):
                     ()
                 else:


### PR DESCRIPTION
Closes #188.

---

TODO: I think we probably want `Peekable` as input. Currently ever token check increments the iterator, so in a symbol like `"foo"*` we have to clone the iterator for every "foo" match to avoid incrementing the iterator when the match fails.

I'll be adding another idea to #188..

Using `Peekable` is also tricky as the cached next item needs to implement `Clone`, but records don't implement `Clone` currently.