### PR TITLE
Add setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to Fir
+
+## Setup
+
+Development requires a stable version of [Rust](https://www.rust-lang.org/). Install the project's dependencies, including the `fir` binary with the following command:
+
+```
+cargo install --path .
+```
+
+You will also need a global installation of libraries [Just](https://github.com/casey/just), [LALRPOP](https://github.com/lalrpop/lalrpop), and [Golden Tests](https://github.com/jfecher/golden-tests).
+
+Installation instructions for Just is provided in its documentation. Install LALRPOP with `cargo install lalrpop`. The Golden Tests library is used as a binary in our `justfile` and can be installed to support this with the following command:
+
+```
+cargo install goldentests --features binary
+```
+
+Use the `just test` command to run the tests.


### PR DESCRIPTION
Add a file outlining instructions to get the `just test` command to run.

I didn't add the instruction about setting the `FIR_ROOT` environment variable. I had a weird experience now where I cannot find references of `FIR_ROOT` anywhere in the repository including the following snippet I found in a `lib.rs` file. The `justfile` also had references to `FIR_ROOT` which are now gone.

```rs
let fir_root = match std::env::var("FIR_ROOT") {
    Ok(fir_root) => {
        let mut path = std::path::PathBuf::new();
        path.push(fir_root);
        path.push("lib");
        path.to_string_lossy().tostring()
    }
    Err() => {
        eprintln!("Fir uses FIR_ROOT environment variable to find standard libraries.");
        eprintln!("Please set FIR_ROOT to Fir git repo root.");
        std::process::exit(1);
    }
};
```

Any ideas about what's happening here? Feels very weird. I am also able to run `just test` successfully without setting `FIR_ROOT`, which wasn't possible when I opened #222. 