### PR TITLE
Interpreter: desugar string interpolations

### DIFF
--- a/Fir/StrBuf.fir
+++ b/Fir/StrBuf.fir
@@ -8,6 +8,10 @@ StrBuf.withCapacity(cap: U32) StrBuf:
     StrBuf(_bytes = Vec.withCapacity(cap))
 
 
+StrBuf.empty() StrBuf:
+    StrBuf.withCapacity(0)
+
+
 StrBuf.len(self) U32:
     self._bytes.len()
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -548,28 +548,12 @@ fn eval<W: Write>(
 
         Expr::Int(int) => ControlFlow::Val(*int),
 
-        Expr::Str(parts) => {
-            let mut bytes: Vec<u8> = vec![];
-            for part in parts {
-                match part {
-                    StringPart::Str(str) => bytes.extend(str.as_bytes()),
-                    StringPart::Expr(expr) => {
-                        let str = val!(eval(
-                            w, pgm, heap, locals, &expr.node, &expr.loc, call_stack
-                        ));
-                        debug_assert_eq!(heap[str], pgm.str_con_idx.as_u64());
-                        let part_bytes = heap.str_bytes(str);
-                        bytes.extend(part_bytes);
-                    }
-                }
-            }
-            ControlFlow::Val(heap.allocate_str(
-                pgm.str_con_idx.as_u64(),
-                pgm.array_u8_con_idx.as_u64(),
-                Repr::U8,
-                &bytes,
-            ))
-        }
+        Expr::Str(str) => ControlFlow::Val(heap.allocate_str(
+            pgm.str_con_idx.as_u64(),
+            pgm.array_u8_con_idx.as_u64(),
+            Repr::U8,
+            str.as_bytes(),
+        )),
 
         Expr::BoolAnd(left, right) => {
             let left = val!(eval(

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -395,7 +395,7 @@ pub enum Expr {
     /// Two's complement representation of an integer value, unsigned extended to `u64`.
     Int(u64),
 
-    Str(Vec<StringPart>),
+    Str(String),
     BoolAnd(Box<L<Expr>>, Box<L<Expr>>),
     BoolOr(Box<L<Expr>>, Box<L<Expr>>),
     Return(Box<L<Expr>>),
@@ -425,12 +425,6 @@ pub struct FieldSelExpr {
 pub struct CallExpr {
     pub fun: Box<L<Expr>>,
     pub args: Vec<L<Expr>>,
-}
-
-#[derive(Debug, Clone)]
-pub enum StringPart {
-    Str(String),
-    Expr(L<Expr>),
 }
 
 #[derive(Debug, Clone)]
@@ -2036,18 +2030,8 @@ fn lower_expr(
             (Expr::Int(value), Default::default(), ty)
         }
 
-        mono::Expr::Str(parts) => (
-            Expr::Str(
-                parts
-                    .iter()
-                    .map(|part| match part {
-                        mono::StringPart::Str(str) => StringPart::Str(str.clone()),
-                        mono::StringPart::Expr(expr) => StringPart::Expr(
-                            lower_l_expr(expr, closures, indices, scope, mono_pgm).0,
-                        ),
-                    })
-                    .collect(),
-            ),
+        mono::Expr::Str(str) => (
+            Expr::Str(str.clone()),
             Default::default(),
             mono::Type::Named(mono::NamedType {
                 name: SmolStr::new_static("Str"),

--- a/src/lowering/printer.rs
+++ b/src/lowering/printer.rs
@@ -280,18 +280,9 @@ impl Expr {
 
             Expr::Int(int) => write!(buffer, "{:#x}", int).unwrap(),
 
-            Expr::Str(parts) => {
+            Expr::Str(str) => {
                 buffer.push('"');
-                for part in parts {
-                    match part {
-                        StringPart::Str(str) => buffer.push_str(str), // TODO: escaping
-                        StringPart::Expr(expr) => {
-                            buffer.push('`');
-                            expr.node.print(buffer, indent);
-                            buffer.push('`');
-                        }
-                    }
-                }
+                buffer.push_str(str); // TODO: escaping
                 buffer.push('"');
             }
 

--- a/src/mono_ast.rs
+++ b/src/mono_ast.rs
@@ -237,7 +237,7 @@ pub enum Expr {
     AssocFnSel(AssocFnSelExpr), // <id>.<id>
     Call(CallExpr),
     Int(IntExpr),
-    Str(Vec<StringPart>),
+    Str(String),
     Char(char),
     BinOp(BinOpExpr),
     Return(Box<L<Expr>>),
@@ -310,10 +310,4 @@ pub struct FnExpr {
 pub struct IsExpr {
     pub expr: Box<L<Expr>>,
     pub pat: L<Pat>,
-}
-
-#[derive(Debug, Clone)]
-pub enum StringPart {
-    Str(String),
-    Expr(L<Expr>),
 }

--- a/src/mono_ast/printer.rs
+++ b/src/mono_ast/printer.rs
@@ -410,18 +410,9 @@ impl Expr {
                 }
             }
 
-            Expr::Str(parts) => {
+            Expr::Str(str) => {
                 buffer.push('"');
-                for part in parts {
-                    match part {
-                        StringPart::Str(str) => buffer.push_str(str), // TODO: escaping
-                        StringPart::Expr(expr) => {
-                            buffer.push('`');
-                            expr.node.print(buffer, 0);
-                            buffer.push('`');
-                        }
-                    }
-                }
+                buffer.push_str(str); // TODO: escaping
                 buffer.push('"');
             }
 

--- a/src/monomorph.rs
+++ b/src/monomorph.rs
@@ -721,17 +721,18 @@ fn mono_expr(
                 .collect(),
         }),
 
-        ast::Expr::Str(parts) => mono::Expr::Str(
-            parts
-                .iter()
-                .map(|part| match part {
-                    StrPart::Str(str) => mono::StringPart::Str(str.clone()),
-                    StrPart::Expr(expr) => mono::StringPart::Expr(mono_l_expr(
-                        expr, ty_map, poly_pgm, mono_pgm, locals,
-                    )),
-                })
-                .collect(),
-        ),
+        ast::Expr::Str(parts) => {
+            if parts.len() != 1 {
+                panic!("{}: Non-desugared string literal", loc_display(loc));
+            }
+            let str = match &parts[0] {
+                StrPart::Expr(_) => {
+                    panic!("{}: Non-desugared string literal", loc_display(loc));
+                }
+                StrPart::Str(str) => str,
+            };
+            mono::Expr::Str(str.clone())
+        }
 
         ast::Expr::BinOp(ast::BinOpExpr { left, right, op }) => {
             mono::Expr::BinOp(mono::BinOpExpr {

--- a/src/record_collector.rs
+++ b/src/record_collector.rs
@@ -206,16 +206,8 @@ fn visit_expr(expr: &mono::Expr, records: &mut HashSet<RecordShape>) {
         | mono::Expr::ConSel(_)
         | mono::Expr::AssocFnSel(_)
         | mono::Expr::Int(_)
-        | mono::Expr::Char(_) => {}
-
-        mono::Expr::Str(parts) => {
-            for part in parts {
-                match part {
-                    mono::StringPart::Str(_) => {}
-                    mono::StringPart::Expr(expr) => visit_expr(&expr.node, records),
-                }
-            }
-        }
+        | mono::Expr::Char(_)
+        | mono::Expr::Str(_) => {}
 
         mono::Expr::FieldSel(mono::FieldSelExpr { object, field: _ }) => {
             visit_expr(&object.node, records);


### PR DESCRIPTION
Convert string interpolations to `StrBuf` calls during type checking.

Similar to the previous desugaring commits, this simplifies the mono and
lowered ASTs and makes it easier to experiment with code generation.

The goal is to eventually generate C or Rust to get unboxed values + a bunch of
other things for free and allow experimenting with different AST designs in the
compiler.