### PR TITLE
Use Fir field names for C struct field names

### DIFF
--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -364,7 +364,7 @@ pub struct SourceConDecl {
     pub con_name: Name,
     pub idx: HeapObjIdx,
     pub ty_args: Vec<mono::Type>,
-    pub fields: Vec<mono::Type>,
+    pub fields: Vec<(Name, mono::Type)>,
     pub sum: bool,
     pub value: bool,
 }
@@ -471,7 +471,7 @@ pub enum Expr {
 pub struct FieldSelExpr {
     pub object: Box<L<Expr>>,
 
-    /// For debugging: name of the field.
+    /// Fir name of the field. Used in C backend.
     pub field: Name,
 
     /// Index of the field in the object's payload.
@@ -1541,8 +1541,15 @@ fn lower_source_con(
         ty_args: con_ty_args.to_vec(),
         fields: match fields {
             mono::ConFields::Empty => vec![],
-            mono::ConFields::Named(fields) => fields.values().cloned().collect(),
-            mono::ConFields::Unnamed(fields) => fields.to_vec(),
+            mono::ConFields::Named(fields) => fields
+                .iter()
+                .map(|(field_name, field_ty)| (field_name.clone(), field_ty.clone()))
+                .collect(),
+            mono::ConFields::Unnamed(fields) => fields
+                .iter()
+                .enumerate()
+                .map(|(i, field_ty)| (Name::new(format!("_{i}")), field_ty.clone()))
+                .collect(),
         },
         sum,
         value,

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -84,6 +84,22 @@ pub enum TypeDecl {
     Variant(VariantType),
 }
 
+impl TypeDecl {
+    pub fn as_named(&self) -> &NamedTypeDecl {
+        match self {
+            TypeDecl::Named(named) => named,
+            _ => panic!(),
+        }
+    }
+
+    pub fn as_record(&self) -> (&RecordType, HeapObjIdx) {
+        match self {
+            TypeDecl::Record(record, heap_obj_idx) => (record, *heap_obj_idx),
+            _ => panic!(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct NamedTypeDecl {
     pub name: Name,

--- a/src/lowering/printer.rs
+++ b/src/lowering/printer.rs
@@ -31,8 +31,8 @@ impl LoweredPgm {
                     p.str(con_name.as_str());
                     print_ty_args(ty_args, p);
                     p.char('(');
-                    p.sep(fields.iter(), ", ", |p, field_ty| {
-                        write!(p, "{field_ty}").unwrap()
+                    p.sep(fields.iter(), ", ", |p, (field_name, field_ty)| {
+                        write!(p, "{field_name}: {field_ty}").unwrap()
                     });
                     p.char(')');
                 }

--- a/src/to_c.rs
+++ b/src/to_c.rs
@@ -279,7 +279,7 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
                         "return (({sum_struct}){{ ._tag = {tag_name}, .{con_field} = {{ ._tag = {tag_name}"
                     );
                     for (i, (field_name, _field_ty)) in source_con.fields.iter().enumerate() {
-                        w!(p, ", .{field_name} = p{i}");
+                        w!(p, ", .{} = p{i}", c_field_name(field_name));
                     }
                     w!(p, " }} }});");
                     p.dedent();
@@ -302,7 +302,7 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
                         source_con.fields.iter().enumerate(),
                         ",",
                         |p, (i, (field_name, _field_ty))| {
-                            w!(p, " .{field_name} = p{i}");
+                            w!(p, " .{} = p{i}", c_field_name(field_name));
                         },
                     );
                     w!(p, " }});");
@@ -324,7 +324,7 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
                         wln!(p, "_obj->_tag = {tag_name};");
                     }
                     for (i, (field_name, _field_ty)) in source_con.fields.iter().enumerate() {
-                        wln!(p, "_obj->{field_name} = p{i};");
+                        wln!(p, "_obj->{} = p{i};", c_field_name(field_name));
                     }
                     w!(p, "return (uint64_t)_obj;");
                     p.dedent();
@@ -571,7 +571,7 @@ fn gen_source_con_struct(
     };
     for (field_name, field_ty) in fields.iter() {
         p.nl();
-        w!(p, "{} {field_name};", c_ty(field_ty, pgm));
+        w!(p, "{} {};", c_ty(field_ty, pgm), c_field_name(field_name));
     }
     p.dedent();
     p.nl();
@@ -791,7 +791,7 @@ fn record_decl_to_c(record: &RecordType, tag: u32, pgm: &LoweredPgm, p: &mut Pri
     p.indent();
     for (field_name, field_ty) in record.fields.iter() {
         p.nl();
-        w!(p, "{} {field_name};", c_ty(field_ty, pgm));
+        w!(p, "{} {};", c_ty(field_ty, pgm), c_field_name(field_name));
     }
     p.dedent();
     p.nl();
@@ -1617,7 +1617,7 @@ fn stmt_to_c(
                 w!(p, "{} {} = ", c_ty(object_ty, cg.pgm), obj_temp);
                 expr_to_c(&object.node, &object.loc, locals, cg, p);
                 wln!(p, "; // {}", loc_display(&object.loc));
-                w!(p, "{obj_temp}->{field} = ");
+                w!(p, "{obj_temp}->{} = ", c_field_name(field));
                 expr_to_c(&rhs.node, &rhs.loc, locals, cg, p);
                 wln!(p, ";");
                 if let Some(result_var) = result_var {
@@ -1747,7 +1747,7 @@ fn expr_to_c(expr: &Expr, loc: &Loc, locals: &[LocalInfo], cg: &mut Cg, p: &mut 
                     "(({ret_struct_name}){{ ._tag = {tag_name}, .{con_field} = {{ ._tag = {tag_name}"
                 );
                 for ((field_name, _field_ty), arg) in fields.iter().zip(args.iter()) {
-                    w!(p, ", .{field_name} = ");
+                    w!(p, ", .{} = ", c_field_name(field_name));
                     expr_to_c(&arg.node, &arg.loc, locals, cg, p);
                 }
                 w!(p, " }} }})");
@@ -1758,7 +1758,7 @@ fn expr_to_c(expr: &Expr, loc: &Loc, locals: &[LocalInfo], cg: &mut Cg, p: &mut 
                     fields.iter().zip(args.iter()),
                     ",",
                     |p, ((field_name, _field_ty), arg)| {
-                        w!(p, " .{field_name} = ");
+                        w!(p, " .{} = ", c_field_name(field_name));
                         expr_to_c(&arg.node, &arg.loc, locals, cg, p);
                     },
                 );
@@ -1775,7 +1775,7 @@ fn expr_to_c(expr: &Expr, loc: &Loc, locals: &[LocalInfo], cg: &mut Cg, p: &mut 
                     wln!(p, "_obj->_tag = {tag_name};");
                 }
                 for ((field_name, _field_ty), arg) in fields.iter().zip(args.iter()) {
-                    w!(p, "_obj->{field_name} = ");
+                    w!(p, "_obj->{} = ", c_field_name(field_name));
                     expr_to_c(&arg.node, &arg.loc, locals, cg, p);
                     wln!(p, ";");
                 }
@@ -1795,9 +1795,9 @@ fn expr_to_c(expr: &Expr, loc: &Loc, locals: &[LocalInfo], cg: &mut Cg, p: &mut 
             w!(p, "(");
             expr_to_c(&object.node, &object.loc, locals, cg, p);
             if is_value_type(object_ty, cg.pgm) {
-                w!(p, ").{field}");
+                w!(p, ").{}", c_field_name(field));
             } else {
-                w!(p, ")->{field}");
+                w!(p, ")->{}", c_field_name(field));
             }
         }
 
@@ -2407,6 +2407,7 @@ fn pat_to_cond(
             let value = is_value_type(scrutinee_ty, cg.pgm);
             let value_sum = is_value_sum_type(con, cg.pgm);
             for ((field_name, field_ty), field_pat) in field_tys.iter().zip(fields.iter()) {
+                let field_name = c_field_name(field_name);
                 let field_expr = if value_sum {
                     format!("({scrutinee})._con_{}.{field_name}", con.as_usize())
                 } else if value {
@@ -2436,7 +2437,7 @@ fn pat_to_cond(
                     if rest_i > 0 {
                         rest_init.push(',');
                     }
-                    let src_field_name = &field_tys[src_field_idx as usize].0;
+                    let src_field_name = c_field_name(&field_tys[src_field_idx as usize].0);
                     let field_expr = if value_sum {
                         format!("({scrutinee})._con_{}.{src_field_name}", con.0)
                     } else if value {
@@ -2444,7 +2445,7 @@ fn pat_to_cond(
                     } else {
                         format!("(({struct_name}*){scrutinee})->{src_field_name}")
                     };
-                    let rest_field_name = rest_field_names[rest_i];
+                    let rest_field_name = c_field_name(rest_field_names[rest_i]);
                     rest_init.push_str(&format!(" .{rest_field_name} = {field_expr}"));
                 }
                 rest_init.push_str(" })");
@@ -2876,5 +2877,45 @@ fn named_type_deps(
     let idx = *named_tys.get(&ty.name).unwrap().get(&ty.args).unwrap();
     if deps.insert(idx) {
         type_decl_deps_(named_tys, record_tys, variant_tys, types, idx, deps);
+    }
+}
+
+fn c_field_name(name: &Name) -> &str {
+    match name.as_str() {
+        "auto" => "auto_",
+        "break" => "break_",
+        "case" => "case_",
+        "char" => "char_",
+        "const" => "const_",
+        "continue" => "continue_",
+        "default" => "default_",
+        "do" => "do_",
+        "double" => "double_",
+        "else" => "else_",
+        "enum" => "enum_",
+        "extern" => "extern_",
+        "float" => "float_",
+        "for" => "for_",
+        "goto" => "goto_",
+        "if" => "if_",
+        "inline" => "inline_",
+        "int" => "int_",
+        "long" => "long_",
+        "register" => "register_",
+        "restrict" => "restrict_",
+        "return" => "return_",
+        "short" => "short_",
+        "signed" => "signed_",
+        "sizeof" => "sizeof_",
+        "static" => "static_",
+        "struct" => "struct_",
+        "switch" => "switch_",
+        "typedef" => "typedef_",
+        "union" => "union_",
+        "unsigned" => "unsigned_",
+        "void" => "void_",
+        "volatile" => "volatile_",
+        "while" => "while_",
+        s => s,
     }
 }

--- a/src/to_c.rs
+++ b/src/to_c.rs
@@ -2507,14 +2507,10 @@ fn generate_main_fn(pgm: &LoweredPgm, main: &str, p: &mut Printer) {
 /// - For boxed sum types: the generated code will read the tag word of the heap allocated object.
 /// - For unboxed sum types: the generated code will read the tag from the struct of the sum type.
 fn gen_get_tag(pgm: &LoweredPgm, expr: &str, ty: &mono::Type) -> String {
-    // For product types, use the tag macro.
     match ty {
         mono::Type::Named(mono::NamedType { name, args }) => {
             let idx = *pgm.named_tys.get(name).unwrap().get(args).unwrap();
-            let named_ty = match &pgm.types[idx.as_usize()] {
-                TypeDecl::Named(ty) => ty,
-                _ => panic!(),
-            };
+            let named_ty = pgm.types[idx.as_usize()].as_named();
             if named_ty.con_indices.len() == 1 {
                 return heap_obj_tag_name(pgm, named_ty.con_indices[0]);
             }
@@ -2531,10 +2527,7 @@ fn gen_get_tag(pgm: &LoweredPgm, expr: &str, ty: &mono::Type) -> String {
                     fields: fields.clone(),
                 })
                 .unwrap();
-            let idx = match &pgm.types[idx.as_usize()] {
-                TypeDecl::Record(_, idx) => *idx,
-                _ => panic!(),
-            };
+            let idx = pgm.types[idx.as_usize()].as_record().1;
             heap_obj_tag_name(pgm, idx)
         }
 

--- a/src/to_c.rs
+++ b/src/to_c.rs
@@ -158,7 +158,7 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
 
         // String comparison for pattern matching
         static bool str_eq(Str s1, const char* str2, size_t len2) {{
-            Array_U8 bytes_arr = s1._0;
+            Array_U8 bytes_arr = s1._bytes;
             uint32_t len1 = (uint32_t)bytes_arr.len;
             if (len1 != len2) return false;
             uint8_t* data_ptr = bytes_arr.data_ptr;
@@ -168,7 +168,7 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
         // Allocate string from bytes, taking ownership of the bytes.
         static Str alloc_str(char* bytes, size_t len) {{
             Array_U8 arr = {{ .data_ptr = (U8*)bytes, .len = len }};
-            return (Str){{ ._0 = arr }};
+            return (Str){{ ._bytes = arr }};
         }}
 
         // Globals for CLI args
@@ -267,8 +267,8 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
                         p,
                         "static {sum_struct} _con_closure_{tag}_fun(CLOSURE* self"
                     );
-                    for (i, ty) in source_con.fields.iter().enumerate() {
-                        w!(p, ", {} p{i}", c_ty(ty, pgm));
+                    for (i, (_field_name, field_ty)) in source_con.fields.iter().enumerate() {
+                        w!(p, ", {} p{i}", c_ty(field_ty, pgm));
                     }
                     w!(p, ") {{");
                     p.indent();
@@ -278,8 +278,8 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
                         p,
                         "return (({sum_struct}){{ ._tag = {tag_name}, .{con_field} = {{ ._tag = {tag_name}"
                     );
-                    for i in 0..source_con.fields.len() {
-                        w!(p, ", ._{i} = p{i}");
+                    for (i, (field_name, _field_ty)) in source_con.fields.iter().enumerate() {
+                        w!(p, ", .{field_name} = p{i}");
                     }
                     w!(p, " }} }});");
                     p.dedent();
@@ -291,16 +291,20 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
                         p,
                         "static {struct_name} _con_closure_{tag}_fun(CLOSURE* self"
                     );
-                    for (i, ty) in source_con.fields.iter().enumerate() {
-                        w!(p, ", {} p{i}", c_ty(ty, pgm));
+                    for (i, (_field_name, field_ty)) in source_con.fields.iter().enumerate() {
+                        w!(p, ", {} p{i}", c_ty(field_ty, pgm));
                     }
                     w!(p, ") {{");
                     p.indent();
                     p.nl();
                     w!(p, "return (({struct_name}){{");
-                    p.sep(0..source_con.fields.len(), ",", |p, i| {
-                        w!(p, " ._{i} = p{i}");
-                    });
+                    p.sep(
+                        source_con.fields.iter().enumerate(),
+                        ",",
+                        |p, (i, (field_name, _field_ty))| {
+                            w!(p, " .{field_name} = p{i}");
+                        },
+                    );
                     w!(p, " }});");
                     p.dedent();
                     p.nl();
@@ -309,8 +313,8 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
                     // Boxed type: heap allocate.
                     let product = is_product_con(&con_idx, pgm);
                     w!(p, "static uint64_t _con_closure_{tag}_fun(CLOSURE* self");
-                    for (i, ty) in source_con.fields.iter().enumerate() {
-                        w!(p, ", {} p{i}", c_ty(ty, pgm));
+                    for (i, (_field_name, field_ty)) in source_con.fields.iter().enumerate() {
+                        w!(p, ", {} p{i}", c_ty(field_ty, pgm));
                     }
                     w!(p, ") {{");
                     p.indent();
@@ -319,8 +323,8 @@ pub(crate) fn to_c(pgm: &LoweredPgm, main: &str) -> String {
                     if !product {
                         wln!(p, "_obj->_tag = {tag_name};");
                     }
-                    for i in 0..source_con.fields.len() {
-                        wln!(p, "_obj->_{i} = p{i};");
+                    for (i, (field_name, _field_ty)) in source_con.fields.iter().enumerate() {
+                        wln!(p, "_obj->{field_name} = p{i};");
                     }
                     w!(p, "return (uint64_t)_obj;");
                     p.dedent();
@@ -553,14 +557,21 @@ fn gen_source_con_struct(
         p.nl();
         w!(p, "uint64_t _tag;");
     }
-    let field_tys: Vec<&mono::Type> = match fields {
+    let fields: Vec<(Name, mono::Type)> = match fields {
         mono::ConFields::Empty => vec![],
-        mono::ConFields::Named(fields) => fields.values().collect(),
-        mono::ConFields::Unnamed(fields) => fields.iter().collect(),
+        mono::ConFields::Named(fields) => fields
+            .iter()
+            .map(|(field_name, field_ty)| (field_name.clone(), field_ty.clone()))
+            .collect(),
+        mono::ConFields::Unnamed(fields) => fields
+            .iter()
+            .enumerate()
+            .map(|(i, field_ty)| (Name::new(format!("_{i}")), field_ty.clone()))
+            .collect(),
     };
-    for (i, field_ty) in field_tys.iter().enumerate() {
+    for (field_name, field_ty) in fields.iter() {
         p.nl();
-        w!(p, "{} _{i};", c_ty(field_ty, pgm));
+        w!(p, "{} {field_name};", c_ty(field_ty, pgm));
     }
     p.dedent();
     p.nl();
@@ -778,9 +789,9 @@ fn record_decl_to_c(record: &RecordType, tag: u32, pgm: &LoweredPgm, p: &mut Pri
 
     w!(p, "typedef struct {struct_name} {{");
     p.indent();
-    for (i, (_field_name, field_ty)) in record.fields.iter().enumerate() {
+    for (field_name, field_ty) in record.fields.iter() {
         p.nl();
-        w!(p, "{} _{i};", c_ty(field_ty, pgm));
+        w!(p, "{} {field_name};", c_ty(field_ty, pgm));
     }
     p.dedent();
     p.nl();
@@ -907,7 +918,7 @@ fn builtin_fun_to_c(
                 p,
                 "
                 static {} _fun_{idx}(Str msg) {{
-                    Array_U8 bytes_arr = msg._0;
+                    Array_U8 bytes_arr = msg._bytes;
                     uint32_t len = (uint32_t)bytes_arr.len;
                     uint8_t* data_ptr = bytes_arr.data_ptr;
                     fprintf(stderr, \"PANIC: \");
@@ -927,7 +938,7 @@ fn builtin_fun_to_c(
                 p,
                 "
                 static {ret_ty} _fun_{idx}(Str str) {{
-                    Array_U8 bytes_arr = str._0;
+                    Array_U8 bytes_arr = str._bytes;
                     uint32_t len = (uint32_t)bytes_arr.len;
                     uint8_t* data_ptr = bytes_arr.data_ptr;
                     fwrite(data_ptr, 1, len, stdout);
@@ -1345,7 +1356,7 @@ fn builtin_fun_to_c(
                 p,
                 "
                 static Str _fun_{idx}(Str path_str) {{
-                    Array_U8 bytes_arr = path_str._0;
+                    Array_U8 bytes_arr = path_str._bytes;
                     uint32_t path_len = (uint32_t)bytes_arr.len;
                     uint8_t* path_data = bytes_arr.data_ptr;
                     char* path = (char*)malloc(path_len + 1);
@@ -1598,15 +1609,15 @@ fn stmt_to_c(
             }
             Expr::FieldSel(FieldSelExpr {
                 object,
-                field: _,
-                idx,
+                field,
+                idx: _,
                 object_ty,
             }) => {
                 let obj_temp = cg.fresh_temp();
                 w!(p, "{} {} = ", c_ty(object_ty, cg.pgm), obj_temp);
                 expr_to_c(&object.node, &object.loc, locals, cg, p);
                 wln!(p, "; // {}", loc_display(&object.loc));
-                w!(p, "{}->_{} = ", obj_temp, idx);
+                w!(p, "{obj_temp}->{field} = ");
                 expr_to_c(&rhs.node, &rhs.loc, locals, cg, p);
                 wln!(p, ";");
                 if let Some(result_var) = result_var {
@@ -1701,6 +1712,25 @@ fn expr_to_c(expr: &Expr, loc: &Loc, locals: &[LocalInfo], cg: &mut Cg, p: &mut 
             args,
             ret_ty,
         } => {
+            let heap_obj = &cg.pgm.heap_objs[heap_obj_idx.as_usize()];
+            let fields: Vec<(Name, mono::Type)> = match heap_obj {
+                HeapObj::Builtin(_) => panic!(),
+                HeapObj::Source(source_con_decl) => source_con_decl
+                    .fields
+                    .iter()
+                    .map(|(field_name, field_ty)| (field_name.clone(), field_ty.clone()))
+                    .collect(),
+                HeapObj::Record(record_type) => record_type
+                    .fields
+                    .iter()
+                    .map(|(field_name, field_ty)| (field_name.clone(), field_ty.clone()))
+                    .collect(),
+                HeapObj::Variant(_) => {
+                    // Variants should be allocated with `Expr::Variant`.
+                    panic!("BUG: Variant in ConAlloc")
+                }
+            };
+            assert_eq!(fields.len(), args.len());
             if args.is_empty() {
                 w!(
                     p,
@@ -1716,18 +1746,22 @@ fn expr_to_c(expr: &Expr, loc: &Loc, locals: &[LocalInfo], cg: &mut Cg, p: &mut 
                     p,
                     "(({ret_struct_name}){{ ._tag = {tag_name}, .{con_field} = {{ ._tag = {tag_name}"
                 );
-                for (i, arg) in args.iter().enumerate() {
-                    w!(p, ", ._{i} = ");
+                for ((field_name, _field_ty), arg) in fields.iter().zip(args.iter()) {
+                    w!(p, ", .{field_name} = ");
                     expr_to_c(&arg.node, &arg.loc, locals, cg, p);
                 }
                 w!(p, " }} }})");
             } else if is_value_type(ret_ty, cg.pgm) {
                 let struct_name = heap_obj_struct_name(cg.pgm, *heap_obj_idx);
                 w!(p, "(({struct_name}){{");
-                p.sep(args.iter().enumerate(), ",", |p, (i, arg)| {
-                    w!(p, " ._{i} = ");
-                    expr_to_c(&arg.node, &arg.loc, locals, cg, p);
-                });
+                p.sep(
+                    fields.iter().zip(args.iter()),
+                    ",",
+                    |p, ((field_name, _field_ty), arg)| {
+                        w!(p, " .{field_name} = ");
+                        expr_to_c(&arg.node, &arg.loc, locals, cg, p);
+                    },
+                );
                 w!(p, " }})");
             } else {
                 let struct_name = heap_obj_struct_name(cg.pgm, *heap_obj_idx);
@@ -1740,8 +1774,8 @@ fn expr_to_c(expr: &Expr, loc: &Loc, locals: &[LocalInfo], cg: &mut Cg, p: &mut 
                     let tag_name = heap_obj_tag_name(cg.pgm, *heap_obj_idx);
                     wln!(p, "_obj->_tag = {tag_name};");
                 }
-                for (i, arg) in args.iter().enumerate() {
-                    w!(p, "_obj->_{i} = ");
+                for ((field_name, _field_ty), arg) in fields.iter().zip(args.iter()) {
+                    w!(p, "_obj->{field_name} = ");
                     expr_to_c(&arg.node, &arg.loc, locals, cg, p);
                     wln!(p, ";");
                 }
@@ -1754,16 +1788,16 @@ fn expr_to_c(expr: &Expr, loc: &Loc, locals: &[LocalInfo], cg: &mut Cg, p: &mut 
 
         Expr::FieldSel(FieldSelExpr {
             object,
-            field: _,
-            idx,
+            field,
+            idx: _,
             object_ty,
         }) => {
             w!(p, "(");
             expr_to_c(&object.node, &object.loc, locals, cg, p);
             if is_value_type(object_ty, cg.pgm) {
-                w!(p, ")._{}", idx);
+                w!(p, ").{field}");
             } else {
-                w!(p, ")->_{}", idx);
+                w!(p, ")->{field}");
             }
         }
 
@@ -2357,24 +2391,29 @@ fn pat_to_cond(
                     format!("({get_tag} == {tag_name})")
                 }
             };
-            let field_tys: Vec<mono::Type> = match &cg.pgm.heap_objs[con.as_usize()] {
+            let field_tys: Vec<(Name, mono::Type)> = match &cg.pgm.heap_objs[con.as_usize()] {
                 HeapObj::Source(source_con) => source_con.fields.clone(),
-                HeapObj::Record(record) => record.fields.values().cloned().collect(),
+                HeapObj::Record(record) => record
+                    .fields
+                    .iter()
+                    .clone()
+                    .map(|(field_name, field_ty)| (field_name.clone(), field_ty.clone()))
+                    .collect(),
                 HeapObj::Builtin(_) => panic!("Builtin constructor {:?} in Pat::Con", con),
                 HeapObj::Variant(_) => panic!("Variant in Pat::Con"),
             };
+            assert_eq!(field_tys.len(), fields.len());
             let mut cond = tag_check;
             let value = is_value_type(scrutinee_ty, cg.pgm);
             let value_sum = is_value_sum_type(con, cg.pgm);
-            for (i, field_pat) in fields.iter().enumerate() {
+            for ((field_name, field_ty), field_pat) in field_tys.iter().zip(fields.iter()) {
                 let field_expr = if value_sum {
-                    format!("({scrutinee})._con_{}._{i}", con.0)
+                    format!("({scrutinee})._con_{}.{field_name}", con.as_usize())
                 } else if value {
-                    format!("({scrutinee})._{i}")
+                    format!("({scrutinee}).{field_name}")
                 } else {
-                    format!("(({struct_name}*){scrutinee})->_{i}")
+                    format!("(({struct_name}*){scrutinee})->{field_name}")
                 };
-                let field_ty = &field_tys[i];
                 let field_cond =
                     pat_to_cond(&field_pat.node, &field_expr, field_ty, None, locals, cg);
                 cond = format!("({cond} && {field_cond})");
@@ -2388,19 +2427,25 @@ fn pat_to_cond(
             } = rest
             {
                 let rest_struct_name = heap_obj_struct_name(cg.pgm, *rest_con);
+                let rest_field_names: Vec<&Name> = match &cg.pgm.heap_objs[rest_con.as_usize()] {
+                    HeapObj::Record(record) => record.fields.keys().collect(),
+                    _ => panic!("BUG: rest_con is not a record"),
+                };
                 let mut rest_init = format!("(({rest_struct_name}){{");
                 for (rest_i, &src_field_idx) in rest_field_indices.iter().enumerate() {
                     if rest_i > 0 {
                         rest_init.push(',');
                     }
+                    let src_field_name = &field_tys[src_field_idx as usize].0;
                     let field_expr = if value_sum {
-                        format!("({scrutinee})._con_{}._{src_field_idx}", con.0)
+                        format!("({scrutinee})._con_{}.{src_field_name}", con.0)
                     } else if value {
-                        format!("({scrutinee})._{src_field_idx}")
+                        format!("({scrutinee}).{src_field_name}")
                     } else {
-                        format!("(({struct_name}*){scrutinee})->_{src_field_idx}")
+                        format!("(({struct_name}*){scrutinee})->{src_field_name}")
                     };
-                    rest_init.push_str(&format!(" ._{rest_i} = {field_expr}"));
+                    let rest_field_name = rest_field_names[rest_i];
+                    rest_init.push_str(&format!(" .{rest_field_name} = {field_expr}"));
                 }
                 rest_init.push_str(" })");
                 cond = format!(
@@ -2444,7 +2489,7 @@ fn pat_to_cond(
                     format!("({get_tag} == {tag_name})")
                 }
             };
-            format!("({tag_check} && ({scrutinee})._0 == {})", *c as u32)
+            format!("({tag_check} && ({scrutinee})._codePoint == {})", *c as u32)
         }
 
         Pat::Or(p1, p2) => {


### PR DESCRIPTION
To deal with extern structs and Fir structs the same way when allocating and accessing fields, this uses Fir field names (instead of `_0`, `_1`, ...) in C struct field names.

It works but we need to modify the field names that are also C keywords. E.g. apparently we use `char` somewhere which is a C keyword.